### PR TITLE
CB-7845: Filter out test records by default

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -75,16 +75,25 @@ class CBX1Stream(RESTStream):
             "pageNumber": next_page_token,
             "pageSize": self.page_size,
         }
+
+        # Always filter out test records (testMetadata: null means not a test record)
+        filters = {
+            "testMetadata": {
+                "type": "EQUALS",
+                "value": None
+            }
+        }
+
         if self.replication_key_field and start_date:
             iso_start_date = start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             iso_now = parse("now").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            payload["filters"] = {
-                self.replication_key_field: {
-                    "type": "BETWEEN",
-                    "value": iso_start_date,
-                    "endValue": iso_now
-                }
+            filters[self.replication_key_field] = {
+                "type": "BETWEEN",
+                "value": iso_start_date,
+                "endValue": iso_now
             }
+
+        payload["filters"] = filters
         return payload
 
     @property


### PR DESCRIPTION
## Summary
- Add `testMetadata` filter with `type: EQUALS` and `value: null` to all list API requests
- Ensures test records (marked with `testMetadata.isTest=true`) are excluded from HotGlue data syncs

## Related PRs
- Backend: https://github.com/CBX1/backend/pull/3115 (main)
- Backend hotfix: https://github.com/CBX1/backend/pull/3127 (production)

## Changes
Modified `prepare_request_payload()` in `client.py` to always include:
```json
{
  "filters": {
    "testMetadata": {
      "type": "EQUALS",
      "value": null
    }
  }
}
```

This filter is combined with the existing `updatedAt` BETWEEN filter for incremental syncs.

## Test plan
- [ ] Deploy to staging and verify contacts/accounts sync excludes test records
- [ ] Verify incremental sync still works correctly with both filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)