### PR TITLE
feat: Add event streams for HubSpot event sync

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -165,7 +165,7 @@ class CBX1EventStream(CBX1Stream):
 
     page_size = 1000
     rest_method = "POST"
-    replication_key_field = "eventTimestamp"
+    replication_key_field = "occurredAt"
 
     def get_url(self, context: dict | None) -> str:
         crm = self.config.get(CRM_KEY)
@@ -174,17 +174,22 @@ class CBX1EventStream(CBX1Stream):
 
     @cached_property
     def schema(self) -> dict:
-        """Return a minimal schema with eventTimestamp typed as datetime.
+        """Schema matching the enrichment-mapped output from the backend.
 
-        Event streams don't use the jsonSchema discovery endpoint.
-        The Singer SDK needs the replication key in the schema to determine
-        its type — without this it raises 'empty type_dict' ValueError.
+        The backend applies TenantEgestionMapping before returning records,
+        so fields here are the MAPPED names (not raw Redshift column names).
+        Using additionalProperties: true so any extra mapped fields pass through.
         """
         return {
             "type": "object",
+            "additionalProperties": True,
             "properties": {
-                "eventTimestamp": {"type": ["string", "null"], "format": "date-time"},
-                "eventId": {"type": ["string", "null"]},
+                "uuid": {"type": ["string", "null"]},
+                "occurredAt": {"type": ["string", "null"], "format": "date-time"},
+                "eventName": {"type": ["string", "null"]},
+                "email": {"type": ["string", "null"]},
+                "objectId": {"type": ["string", "null"]},
+                "properties": {"type": ["object", "null"]},
             },
         }
 

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -165,12 +165,28 @@ class CBX1EventStream(CBX1Stream):
 
     page_size = 1000
     rest_method = "POST"
-    replication_key_field = "event_timestamp"
+    replication_key_field = "eventTimestamp"
 
     def get_url(self, context: dict | None) -> str:
         crm = self.config.get(CRM_KEY)
         url = "".join([self.url_base, self.path or "", f"/{crm}/events"])
         return url
+
+    @cached_property
+    def schema(self) -> dict:
+        """Return a minimal schema with eventTimestamp typed as datetime.
+
+        Event streams don't use the jsonSchema discovery endpoint.
+        The Singer SDK needs the replication key in the schema to determine
+        its type — without this it raises 'empty type_dict' ValueError.
+        """
+        return {
+            "type": "object",
+            "properties": {
+                "eventTimestamp": {"type": ["string", "null"], "format": "date-time"},
+                "eventId": {"type": ["string", "null"]},
+            },
+        }
 
     def prepare_request_payload(
             self,
@@ -183,14 +199,15 @@ class CBX1EventStream(CBX1Stream):
             "botFilterEnabled": self.config.get("bot_filter", True),
         }
 
-        # next_page_token is the cursor (ISO timestamp string) from previous response
-        if next_page_token:
-            payload["cursor"] = next_page_token
+        # next_page_token is a dict {lastCreatedAt, lastEventId} from previous response
+        if next_page_token and isinstance(next_page_token, dict):
+            payload["lastCreatedAt"] = next_page_token.get("lastCreatedAt")
+            payload["lastEventId"] = next_page_token.get("lastEventId")
         else:
-            # First page - use replication key bookmark or start_date
-            start_date = self.get_starting_time(context)
+            # First page - use start_date from config if available
+            start_date = self.config.get("start_date")
             if start_date:
-                payload["cursor"] = start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                payload["lastCreatedAt"] = start_date
 
         # Add event actions filter if configured
         event_actions = getattr(self, 'event_actions', None)
@@ -202,10 +219,13 @@ class CBX1EventStream(CBX1Stream):
     def get_next_page_token(
             self, response: requests.Response, previous_token: Any | None
     ) -> Any | None:
-        """Return the nextCursor if hasMore is true, else None."""
+        """Return compound cursor {lastCreatedAt, lastEventId} if hasMore, else None."""
         data = response.json().get('data', {})
         if data.get('hasMore', False):
-            return data.get('nextCursor')
+            return {
+                "lastCreatedAt": data.get('nextCursor'),
+                "lastEventId": data.get('nextEventId'),
+            }
         return None
 
     def request_records(self, context: dict | None) -> Iterable[dict]:

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -184,12 +184,22 @@ class CBX1EventStream(CBX1Stream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
+                "inputs": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "uuid": {"type": ["string", "null"]},
+                            "occurredAt": {"type": ["string", "null"], "format": "date-time"},
+                            "eventName": {"type": ["string", "null"]},
+                            "email": {"type": ["string", "null"]},
+                            "objectId": {"type": ["string", "null"]},
+                            "properties": {"type": ["object", "null"]},
+                        },
+                    },
+                },
                 "uuid": {"type": ["string", "null"]},
                 "occurredAt": {"type": ["string", "null"], "format": "date-time"},
-                "eventName": {"type": ["string", "null"]},
-                "email": {"type": ["string", "null"]},
-                "objectId": {"type": ["string", "null"]},
-                "properties": {"type": ["object", "null"]},
             },
         }
 
@@ -234,7 +244,12 @@ class CBX1EventStream(CBX1Stream):
         return None
 
     def request_records(self, context: dict | None) -> Iterable[dict]:
-        """Override to handle keyset pagination response format."""
+        """Yield one record per page — each record is a batch of events.
+
+        Each yielded record contains an 'inputs' array with all events from
+        that page, matching HubSpot's bulk custom events API format.
+        The 'occurredAt' is taken from the last event for replication key tracking.
+        """
         next_page_token = None
         decorated_request = self.request_decorator(self._request)
         finished = False
@@ -248,8 +263,14 @@ class CBX1EventStream(CBX1Stream):
             data = resp.json().get('data', {})
             records = data.get('records', [])
 
-            for record in records:
-                yield record
+            if records:
+                # Yield the whole page as a single batch record
+                last_record = records[-1]
+                yield {
+                    "inputs": records,
+                    "uuid": last_record.get("uuid", ""),
+                    "occurredAt": last_record.get("occurredAt", ""),
+                }
 
             next_page_token = self.get_next_page_token(resp, next_page_token)
             finished = next_page_token is None

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -158,3 +158,73 @@ class CBX1Stream(RESTStream):
     def schema(self) -> dict:
         """Cached schema property."""
         return self.get_schema()
+
+
+class CBX1EventStream(CBX1Stream):
+    """Base class for event streams using keyset (cursor-based) pagination."""
+
+    page_size = 1000
+    rest_method = "POST"
+    replication_key_field = "event_timestamp"
+
+    def get_url(self, context: dict | None) -> str:
+        crm = self.config.get(CRM_KEY)
+        url = "".join([self.url_base, self.path or "", f"/{crm}/events"])
+        return url
+
+    def prepare_request_payload(
+            self,
+            context: dict | None,
+            next_page_token: Any | None,
+    ) -> dict | None:
+        """Build keyset pagination request payload."""
+        payload = {
+            "pageSize": self.page_size,
+            "botFilterEnabled": self.config.get("bot_filter", True),
+        }
+
+        # next_page_token is the cursor (ISO timestamp string) from previous response
+        if next_page_token:
+            payload["cursor"] = next_page_token
+        else:
+            # First page - use replication key bookmark or start_date
+            start_date = self.get_starting_time(context)
+            if start_date:
+                payload["cursor"] = start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        # Add event actions filter if configured
+        event_actions = getattr(self, 'event_actions', None)
+        if event_actions:
+            payload["eventActions"] = event_actions
+
+        return payload
+
+    def get_next_page_token(
+            self, response: requests.Response, previous_token: Any | None
+    ) -> Any | None:
+        """Return the nextCursor if hasMore is true, else None."""
+        data = response.json().get('data', {})
+        if data.get('hasMore', False):
+            return data.get('nextCursor')
+        return None
+
+    def request_records(self, context: dict | None) -> Iterable[dict]:
+        """Override to handle keyset pagination response format."""
+        next_page_token = None
+        decorated_request = self.request_decorator(self._request)
+        finished = False
+
+        while not finished:
+            prepared_request = self.prepare_request(
+                context,
+                next_page_token=next_page_token
+            )
+            resp = decorated_request(prepared_request, context)
+            data = resp.json().get('data', {})
+            records = data.get('records', [])
+
+            for record in records:
+                yield record
+
+            next_page_token = self.get_next_page_token(resp, next_page_token)
+            finished = next_page_token is None

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -17,9 +17,8 @@ class EmailEventStream(CBX1EventStream):
     name = "email_events"
     path = "/EMAIL_EVENT"
     target_name = "EMAIL_EVENT"
-    primary_keys = ["id"]
-    replication_key = "event_timestamp"
-    event_actions = ["open", "click"]
+    primary_keys = ["eventId"]
+    replication_key = "eventTimestamp"
 
 
 class FormEventStream(CBX1EventStream):
@@ -27,15 +26,14 @@ class FormEventStream(CBX1EventStream):
     name = "form_events"
     path = "/FORM_EVENT"
     target_name = "FORM_EVENT"
-    primary_keys = ["id"]
-    replication_key = "event_timestamp"
+    primary_keys = ["eventId"]
+    replication_key = "eventTimestamp"
 
 
-class PageVisitStream(CBX1EventStream):
-    """Page visit stream."""
-    name = "page_visits"
-    path = "/PAGE_VISIT"
-    target_name = "PAGE_VISIT"
-    primary_keys = ["id"]
-    replication_key = "event_timestamp"
-
+class PageEventStream(CBX1EventStream):
+    """Page event stream."""
+    name = "page_events"
+    path = "/PAGE_EVENT"
+    target_name = "PAGE_EVENT"
+    primary_keys = ["eventId"]
+    replication_key = "eventTimestamp"

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -1,4 +1,4 @@
-from tap_cbx1.client import CBX1Stream
+from tap_cbx1.client import CBX1Stream, CBX1EventStream
 
 
 
@@ -12,29 +12,30 @@ class ContactStream(CBX1Stream):
     replication_key = "updatedAt"
 
 
-class EmailEventStream(CBX1Stream):
+class EmailEventStream(CBX1EventStream):
     """Email event stream (opens, clicks)."""
     name = "email_events"
     path = "/EMAIL_EVENT"
     target_name = "EMAIL_EVENT"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "event_timestamp"
+    event_actions = ["open", "click"]
 
 
-class FormEventStream(CBX1Stream):
+class FormEventStream(CBX1EventStream):
     """Form event stream (form submissions)."""
     name = "form_events"
     path = "/FORM_EVENT"
     target_name = "FORM_EVENT"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "event_timestamp"
 
 
-class PageVisitStream(CBX1Stream):
+class PageVisitStream(CBX1EventStream):
     """Page visit stream."""
     name = "page_visits"
     path = "/PAGE_VISIT"
     target_name = "PAGE_VISIT"
     primary_keys = ["id"]
-    replication_key = "updatedAt"
+    replication_key = "event_timestamp"
 

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -17,8 +17,8 @@ class EmailEventStream(CBX1EventStream):
     name = "email_events"
     path = "/EMAIL_EVENT"
     target_name = "EMAIL_EVENT"
-    primary_keys = ["eventId"]
-    replication_key = "eventTimestamp"
+    primary_keys = ["uuid"]
+    replication_key = "occurredAt"
 
 
 class FormEventStream(CBX1EventStream):
@@ -26,8 +26,8 @@ class FormEventStream(CBX1EventStream):
     name = "form_events"
     path = "/FORM_EVENT"
     target_name = "FORM_EVENT"
-    primary_keys = ["eventId"]
-    replication_key = "eventTimestamp"
+    primary_keys = ["uuid"]
+    replication_key = "occurredAt"
 
 
 class PageEventStream(CBX1EventStream):
@@ -35,5 +35,5 @@ class PageEventStream(CBX1EventStream):
     name = "page_events"
     path = "/PAGE_EVENT"
     target_name = "PAGE_EVENT"
-    primary_keys = ["eventId"]
-    replication_key = "eventTimestamp"
+    primary_keys = ["uuid"]
+    replication_key = "occurredAt"

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -11,3 +11,30 @@ class ContactStream(CBX1Stream):
     primary_keys = ["id"]
     replication_key = "updatedAt"
 
+
+class EmailEventStream(CBX1Stream):
+    """Email event stream (opens, clicks)."""
+    name = "email_events"
+    path = "/EMAIL_EVENT"
+    target_name = "EMAIL_EVENT"
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+
+
+class FormEventStream(CBX1Stream):
+    """Form event stream (form submissions)."""
+    name = "form_events"
+    path = "/FORM_EVENT"
+    target_name = "FORM_EVENT"
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+
+
+class PageVisitStream(CBX1Stream):
+    """Page visit stream."""
+    name = "page_visits"
+    path = "/PAGE_VISIT"
+    target_name = "PAGE_VISIT"
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+

--- a/tap_cbx1/tap.py
+++ b/tap_cbx1/tap.py
@@ -7,10 +7,13 @@ from singer_sdk import typing as th
 
 from tap_cbx1.client import CBX1Stream
 from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY
-from tap_cbx1.streams import  ContactStream
+from tap_cbx1.streams import ContactStream, EmailEventStream, FormEventStream, PageVisitStream
 
 STREAM_TYPES = [
     ContactStream,
+    EmailEventStream,
+    FormEventStream,
+    PageVisitStream,
 ]
 
 class TapCBX1(Tap):
@@ -31,11 +34,25 @@ class TapCBX1(Tap):
 
     config_jsonschema = th.PropertiesList(
         th.Property(CODE_KEY, th.StringType, required=True),
-        th.Property(ORG_ID_KEY, th.StringType, required=True)
+        th.Property(ORG_ID_KEY, th.StringType, required=True),
+        th.Property(
+            "enabled_streams",
+            th.ArrayType(th.StringType),
+            required=False,
+            description="List of stream names to enable. If not set, only 'contacts' is enabled for backward compatibility.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[CBX1Stream]:
-        return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+        enabled = self.config.get("enabled_streams")
+        if enabled is None:
+            # Backward compatible: only contacts if not specified
+            return [ContactStream(tap=self)]
+        return [
+            stream_class(tap=self)
+            for stream_class in STREAM_TYPES
+            if stream_class.name in enabled
+        ]
 
 
 if __name__ == "__main__":

--- a/tap_cbx1/tap.py
+++ b/tap_cbx1/tap.py
@@ -7,13 +7,13 @@ from singer_sdk import typing as th
 
 from tap_cbx1.client import CBX1Stream
 from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY
-from tap_cbx1.streams import ContactStream, EmailEventStream, FormEventStream, PageVisitStream
+from tap_cbx1.streams import ContactStream, EmailEventStream, FormEventStream, PageEventStream
 
 STREAM_TYPES = [
     ContactStream,
     EmailEventStream,
     FormEventStream,
-    PageVisitStream,
+    PageEventStream,
 ]
 
 class TapCBX1(Tap):


### PR DESCRIPTION
## Summary
- Add 3 new Singer streams: `EmailEventStream`, `FormEventStream`, `PageVisitStream`
- Each reads from the CBX1 egestion API (`/EMAIL_EVENT`, `/FORM_EVENT`, `/PAGE_VISIT` paths)
- Add `enabled_streams` config option for per-tenant stream selection
- Backward compatible: defaults to contacts-only when `enabled_streams` not set

## Related PRs
- Backend: CBX1/backend — `feat/hubspot-event-sync`
- Frontend: CBX1/frontend — `feat/hubspot-event-sync`
- HotGlue ETL: CBX1/hotglue-transformation-scripts — `feat/hubspot-event-sync-etl`

## Test plan
- [ ] Run tap locally with default config — verify only contacts stream emits
- [ ] Run with `enabled_streams: ["contacts", "email_events"]` — verify both streams emit
- [ ] Verify schema discovery works for new event types (requires backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)