### PR TITLE
feat(tap): add AccountStream for ACCOUNT egestion (CB-10918)

### DIFF
--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -1,13 +1,20 @@
 from tap_cbx1.client import CBX1Stream
 
 
-
-
 class ContactStream(CBX1Stream):
     """Contact stream with dynamic schema discovery."""
     name = "contacts"
     path = "/CONTACT"
     target_name = "CONTACT"
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+
+
+class AccountStream(CBX1Stream):
+    """Account stream with dynamic schema discovery."""
+    name = "accounts"
+    path = "/ACCOUNT"
+    target_name = "ACCOUNT"
     primary_keys = ["id"]
     replication_key = "updatedAt"
 

--- a/tap_cbx1/tap.py
+++ b/tap_cbx1/tap.py
@@ -7,10 +7,11 @@ from singer_sdk import typing as th
 
 from tap_cbx1.client import CBX1Stream
 from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY
-from tap_cbx1.streams import  ContactStream
+from tap_cbx1.streams import AccountStream, ContactStream
 
 STREAM_TYPES = [
     ContactStream,
+    AccountStream,
 ]
 
 class TapCBX1(Tap):


### PR DESCRIPTION
## Summary

- Adds `AccountStream` to the tap so HotGlue emits an `accounts` stream into `sync-output/`
- The ETL transformation (`hubspot_handler._handle_accounts_write`) was already waiting for this stream — without it, `list_available_streams()` never returned `"accounts"` and the accounts write path was unreachable
- `AccountStream` follows the identical pattern as `ContactStream`: dynamic schema via `/ACCOUNT` egestion endpoint, `updatedAt` replication key

## Files changed

- `tap_cbx1/streams.py` — added `AccountStream`
- `tap_cbx1/tap.py` — imported and registered in `STREAM_TYPES`

## Related

- Transformation scripts PR: CBX1/hotglue-transformation-scripts#10
- Ticket: CB-10918

## Test plan

- [ ] Run tap discovery (`tap-cbx1 --discover`) and confirm `accounts` stream appears in catalog
- [ ] Run tap sync for a tenant with `TenantEgestionMapping ACCOUNT→HUBSPOT` configured and confirm `accounts` data in `sync-output/`
- [ ] Run tap sync for a tenant without the mapping — confirm `accounts` stream is still emitted (stream always present; ETL handler skips gracefully based on `stream_name_mapping`)
- [ ] Confirm existing `contacts` stream is unaffected