### PR TITLE
chore: promote main to production

### DIFF
--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -1,13 +1,20 @@
 from tap_cbx1.client import CBX1Stream
 
 
-
-
 class ContactStream(CBX1Stream):
     """Contact stream with dynamic schema discovery."""
     name = "contacts"
     path = "/CONTACT"
     target_name = "CONTACT"
+    primary_keys = ["id"]
+    replication_key = "updatedAt"
+
+
+class AccountStream(CBX1Stream):
+    """Account stream with dynamic schema discovery."""
+    name = "accounts"
+    path = "/ACCOUNT"
+    target_name = "ACCOUNT"
     primary_keys = ["id"]
     replication_key = "updatedAt"
 

--- a/tap_cbx1/tap.py
+++ b/tap_cbx1/tap.py
@@ -7,10 +7,11 @@ from singer_sdk import typing as th
 
 from tap_cbx1.client import CBX1Stream
 from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY
-from tap_cbx1.streams import  ContactStream
+from tap_cbx1.streams import AccountStream, ContactStream
 
 STREAM_TYPES = [
     ContactStream,
+    AccountStream,
 ]
 
 class TapCBX1(Tap):


### PR DESCRIPTION
## Summary

Promotes all changes on `main` to `production`.

## Key change included

- **CB-10918** — `AccountStream` added to the tap so HotGlue emits an `accounts` stream, enabling the conditional HubSpot account write flow in the transformation scripts.

## Related PRs

- CBX1/cbx1-tap-hotglue#9 — AccountStream (CB-10918)
- CBX1/hotglue-transformation-scripts#10 — HubSpot conditional account write (CB-10918)