### PR TITLE
fix(tap): graceful fallback for AccountStream when no egestion mapping (CB-10918)

### DIFF
--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -1,4 +1,18 @@
+import logging
+from typing import Iterable
+
+from singer_sdk import typing as th
+
 from tap_cbx1.client import CBX1Stream
+
+logger = logging.getLogger(__name__)
+
+# Minimal Singer schema used when no ACCOUNT egestion mapping is configured for a tenant.
+# Provides the primary key and replication key so discovery succeeds; sync yields nothing.
+_ACCOUNT_FALLBACK_SCHEMA = th.PropertiesList(
+    th.Property("id", th.StringType),
+    th.Property("updatedAt", th.DateTimeType),
+).to_dict()
 
 
 class ContactStream(CBX1Stream):
@@ -11,10 +25,36 @@ class ContactStream(CBX1Stream):
 
 
 class AccountStream(CBX1Stream):
-    """Account stream with dynamic schema discovery."""
+    """Account stream with dynamic schema discovery.
+
+    Gracefully skips tenants that have no TenantEgestionMapping for ACCOUNT→CRM:
+    - Discovery: falls back to a minimal schema instead of raising RuntimeError
+    - Sync: yields no records if the list endpoint returns a non-2xx response
+    """
     name = "accounts"
     path = "/ACCOUNT"
     target_name = "ACCOUNT"
     primary_keys = ["id"]
     replication_key = "updatedAt"
+
+    def get_schema(self) -> dict:
+        try:
+            return super().get_schema()
+        except RuntimeError:
+            logger.warning(
+                "No ACCOUNT egestion mapping configured for this tenant "
+                "(CRM=%s); using fallback schema — stream will produce no records.",
+                self.config.get("CRMSystem"),
+            )
+            return _ACCOUNT_FALLBACK_SCHEMA
+
+    def request_records(self, context) -> Iterable[dict]:
+        try:
+            yield from super().request_records(context)
+        except Exception as e:
+            logger.warning(
+                "Could not fetch account records for this tenant "
+                "(likely no ACCOUNT egestion mapping configured): %s",
+                e,
+            )
 


### PR DESCRIPTION
## Summary

- Fixes `DISCOVER_FAILED` for tenants that don't have a `TenantEgestionMapping` configured for `ACCOUNT → CRM`
- `AccountStream` now overrides two methods to handle the missing-mapping case silently instead of crashing

## Root Cause

When `AccountStream` was added, the backend's `/ACCOUNT/{crm}/jsonSchema` endpoint returns 400 for tenants without an `ACCOUNT → HUBSPOT` egestion mapping. `CBX1Stream.get_schema()` treated any `None` return from `fetch_schema_from_api` as a hard failure and raised `RuntimeError` → DISCOVER_FAILED for all such tenants.

## Changes

**`tap_cbx1/streams.py`**

- `AccountStream.get_schema()` — catches `RuntimeError`, logs a warning, returns a minimal fallback schema (`id` + `updatedAt`) so discovery always succeeds
- `AccountStream.request_records()` — catches any exception from the list endpoint and yields nothing, so sync completes cleanly with 0 account records for unmapped tenants

`ContactStream` is unaffected — all tenants have a contact mapping.

## Behaviour by tenant

| Tenant state | Discovery | Sync |
|---|---|---|
| Has `ACCOUNT → HUBSPOT` mapping | Full schema from API | Emits account records |
| No mapping configured | Minimal fallback schema (warning logged) | 0 records, clean exit |

## Related

- PR #9 — AccountStream initial addition (CB-10918)
- CBX1/hotglue-transformation-scripts#10 — HubSpot conditional account write (CB-10918)
- Ticket: CB-10918