### PR TITLE
fix(client): explicit sortBy=updatedAt DESC on egestion list calls (#13)

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -77,6 +77,8 @@ class CBX1Stream(RESTStream):
         payload = {
             "pageNumber": next_page_token,
             "pageSize": self.page_size,
+            "sortBy": self.replication_key_field,
+            "sortDirection": "DESC",
         }
 
         # Always filter out test records (testMetadata: null means not a test record)


### PR DESCRIPTION
Forward-port of #13 (already merged to `main`) to the `production` branch.

## Summary

The egestion list endpoint (`POST /api/t/v1/targets/integrations/{ACCOUNT|CONTACT}/{target}/list`) defaults `sortBy` to `createdAt` when the caller omits it (backend `EntityFilterRequest.sortBy = "createdAt"` is the framework default). Tap calls were timing out on large tenants because that sort cannot be served by the new `orgId_deletedAt_updatedAt_idx` partial index (added in backend hotfix CBX1/backend#4192) — the planner falls back to in-memory sort over the full `orgId` range and trips `maxTimeMS=1000`.

Sends `sortBy` / `sortDirection` explicitly so the planner picks the new `(orgId, deletedAt, updatedAt)` compound index, which serves both the `updatedAt` range filter and the sort end-to-end.

- `sortBy` reuses `self.replication_key_field` (already `"updatedAt"`) so the sort and the bookmark cursor stay in sync.
- `sortDirection: "DESC"` matches the backend index direction (`updatedAt:-1`).

## Test plan

- [x] Cherry-pick of merged main commit `096e3c3` — clean apply, no conflicts.
- [x] Python syntax check on `tap_cbx1/client.py`.
- [ ] Post-deploy: confirm `orgId_deletedAt_updatedAt_idx.usage` increments on `AccountV2`/`ContactV2` after the next tap-cbx1 sync run.
- [ ] Post-deploy: re-run the previously failing tap-cbx1 sync and confirm `/CONTACT` and `/ACCOUNT` no longer 500.