### PR TITLE
Merge pull request #13 from CBX1/main

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -77,6 +77,8 @@ class CBX1Stream(RESTStream):
         payload = {
             "pageNumber": next_page_token,
             "pageSize": self.page_size,
+            "sortBy": self.replication_key_field,
+            "sortDirection": "DESC",
         }
 
         # Always filter out test records (testMetadata: null means not a test record)


### PR DESCRIPTION
Promote `main` to `production`.

Includes:

- #13 — fix(client): explicit `sortBy=updatedAt DESC` on egestion list calls. Forces the backend planner to pick the new `(orgId, deletedAt, updatedAt)` partial index (added in backend hotfix CBX1/backend#4192) instead of falling back to in-memory sort + `maxTimeMS=1000` timeouts on large tenants.

## Test plan

- [x] PR #13 already merged and validated on `main`.
- [ ] Post-deploy: confirm `orgId_deletedAt_updatedAt_idx.usage` increments on `AccountV2`/`ContactV2` after the next tap-cbx1 sync run.
- [ ] Post-deploy: re-run the previously failing tap-cbx1 sync and confirm `/CONTACT` and `/ACCOUNT` no longer 500.