### PR TITLE
fix(tap): keyset pagination on updatedAt — fix HubSpot SYNC_FAILED on large tenants

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -15,6 +15,12 @@ from tap_cbx1.constants import CRM_KEY, HOTGLUE_PRINCIPAL_ID_ENV
 
 _TToken = TypeVar("_TToken")
 
+# ISO-8601 millisecond format the backend BETWEEN filter expects.
+_ISO_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+# Lower bound for a first/full sync (no replication bookmark yet) so the request
+# still has a bounded BETWEEN window the keyset cursor can walk down.
+_EPOCH = parse("1970-01-01T00:00:00Z")
+
 
 class CBX1Stream(RESTStream):
     """CBX1 stream class."""
@@ -26,7 +32,10 @@ class CBX1Stream(RESTStream):
     def url_base(self):
         return os.getenv("BASE_URL") + "api/t/v1/targets/integrations"
 
-    page_size = 10
+    # Keyset pagination keeps every request on page 0 (a ~7ms index seek
+    # regardless of org size), so a larger page is purely fewer round-trips with
+    # no skip cost.
+    page_size = 100
     rest_method = "POST"
     replication_key_field = "updatedAt"
 
@@ -38,38 +47,46 @@ class CBX1Stream(RESTStream):
     def get_next_page_token(
             self, response: requests.Response, previous_token: Optional[Any]
     ) -> Optional[Any]:
-        """Return a token for identifying next page or None if no more pages.
+        """Return the keyset cursor for the next page, or None when done.
 
-        Terminates on ``data.last`` (a boolean the backend already returns)
-        rather than ``data.totalPages``. Computing ``totalPages`` forces the
-        backend to run a per-page full-partition Mongo ``count()`` which drives
-        the prod primary to ~94% CPU; the count-free backend therefore returns
-        ``null`` for ``totalElements``/``totalPages`` while still sending
-        ``last``. We never do arithmetic on a possibly-null ``totalPages``.
+        KEYSET (not offset): records come back sorted by ``updatedAt`` DESC, so
+        the last record on a full page carries the page's minimum ``updatedAt``.
+        We return that timestamp as the cursor; the next request asks for the
+        window up to (and including) it — an index range seek, ~7ms regardless
+        of how far the sync has progressed. The old offset scheme
+        (``previous_token + 1`` -> ``skip(pageNumber*pageSize)``) made deep pages
+        scan the whole tenant partition and blow the backend's 1s ``maxTimeMS``
+        on large orgs (HotGlue ``SYNC_FAILED`` / 500 on ``/CONTACT``).
+
+        Termination still uses ``data.last`` (the backend already returns it),
+        falling back to a short page; we never do arithmetic on a possibly-null
+        ``totalPages``.
         """
-        previous_token = previous_token or 0
         page_data = response.json().get('data') or {}
         content = page_data.get('content') or []
 
         # Primary signal: the backend says this is the final page.
-        # Works for both the current Page DTO and the future count-free Slice.
+        # Works for both the current Page DTO and the count-free Slice.
         if page_data.get('last') is True:
             return None
 
         # Defensive: a short or empty page means there is nothing after it.
-        # Handles a backend that omits `last` entirely.
         if len(content) < self.page_size:
             return None
 
-        # Legacy fallback ONLY when `last` is absent: stop on the last page by
-        # index. Never compare when totalPages is None (would TypeError).
+        # Legacy fallback ONLY when `last` is absent. With keyset every request is
+        # pageNumber=0, so `number` is always 0 and this only fires when the whole
+        # remaining window fits in one page (totalPages<=1) — i.e. the last page.
         if page_data.get('last') is None:
             number = page_data.get('number')
             total_pages = page_data.get('totalPages')
             if number is not None and total_pages is not None and number >= total_pages - 1:
                 return None
 
-        return previous_token + 1
+        # Cursor = minimum updatedAt on this (full, DESC-sorted) page = last record.
+        # Inclusive upper bound; request_records de-dups the boundary record(s) by id.
+        last_rec = content[-1] if content else None
+        return last_rec.get(self.replication_key_field) if last_rec else None
 
     def get_starting_time(self, context):
         start_date = self.config.get("start_date")
@@ -98,11 +115,14 @@ class CBX1Stream(RESTStream):
             next_page_token: _TToken | None,
     ) -> dict | None:
         start_date = self.get_starting_time(context)
+        rep = self.replication_key_field
 
+        # Keyset: always page 0. The cursor moves (the BETWEEN upper bound below),
+        # never the offset — so the backend never does skip(pageNumber*pageSize).
         payload = {
-            "pageNumber": next_page_token,
+            "pageNumber": 0,
             "pageSize": self.page_size,
-            "sortBy": self.replication_key_field,
+            "sortBy": rep,
             "sortDirection": "DESC",
         }
 
@@ -114,15 +134,21 @@ class CBX1Stream(RESTStream):
             }
         }
 
-        if self.replication_key_field and start_date:
-            # Increment start date by 1 millisecond
-            start_date = start_date + timedelta(milliseconds=1)
-            iso_start_date = start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            iso_now = parse("now").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            filters[self.replication_key_field] = {
+        if rep:
+            # Lower bound: the incremental floor (bookmark / start_date). Default to
+            # epoch on a first/full sync so the window is still bounded for keyset.
+            if start_date:
+                lower = (start_date + timedelta(milliseconds=1)).strftime(_ISO_FMT)
+            else:
+                lower = _EPOCH.strftime(_ISO_FMT)
+            # Upper bound: the keyset cursor (previous page's min updatedAt), or
+            # "now" for the first page. Inclusive — request_records de-dups the
+            # boundary record(s) by id so the inclusive bound never re-emits them.
+            upper = (parse(next_page_token) if next_page_token else parse("now")).strftime(_ISO_FMT)
+            filters[rep] = {
                 "type": "BETWEEN",
-                "value": iso_start_date,
-                "endValue": iso_now
+                "value": lower,
+                "endValue": upper,
             }
 
         payload["filters"] = filters
@@ -134,29 +160,55 @@ class CBX1Stream(RESTStream):
         return result
 
     def request_records(self, context: dict | None) -> Iterable[dict]:
-        next_page_token = 0
         decorated_request = self.request_decorator(self._request)
-        finished = False
         # Tap-side filter: drop records HotGlue itself last-modified to avoid re-ingesting our own
         # writes. Pushed-down `$ne updatedBy` regresses Mongo on tenants where HotGlue dominates.
         hotglue_principal_id = os.getenv(HOTGLUE_PRINCIPAL_ID_ENV)
+        rep = self.replication_key_field
         skipped = 0
 
-        while not finished:
+        next_page_token = None        # keyset cursor; None => first page (upper = now)
+        seen_at_cursor: set = set()   # ids already emitted at the current cursor boundary
+
+        while True:
             prepared_request = self.prepare_request(
                 context,
                 next_page_token=next_page_token
             )
             resp = decorated_request(prepared_request, context)
-            response_content = resp.json().get('data').get('content')
+            response_content = (resp.json().get('data') or {}).get('content') or []
+
             for content in response_content:
+                # De-dup the inclusive keyset boundary: a record at exactly the
+                # cursor timestamp that we already emitted on the previous page.
+                if next_page_token is not None and rep \
+                        and content.get(rep) == next_page_token \
+                        and content.get("id") in seen_at_cursor:
+                    continue
                 if hotglue_principal_id and content.get("updatedBy") == hotglue_principal_id:
                     skipped += 1
                     continue
                 yield content
 
-            next_page_token = self.get_next_page_token(resp, next_page_token)
-            finished = next_page_token is None
+            new_token = self.get_next_page_token(resp, next_page_token)
+            if new_token is None:
+                break
+            # No-progress guard: a full page whose records all share one updatedAt
+            # cannot advance an updatedAt-only cursor. Real data tops out at a
+            # couple per instant; bail loudly rather than loop forever.
+            if new_token == next_page_token:
+                self.logger.warning(
+                    "Keyset cursor stalled at %s (a full page shares one updatedAt); "
+                    "stopping to avoid an infinite loop. Paging this tenant would need "
+                    "a compound (updatedAt,_id) cursor plus a backend _id index.",
+                    new_token,
+                )
+                break
+            # Remember the ids at the new boundary so the next page skips them.
+            seen_at_cursor = {
+                r.get("id") for r in response_content if rep and r.get(rep) == new_token
+            }
+            next_page_token = new_token
 
         if hotglue_principal_id and skipped:
             self.logger.info("Skipped %d records last-modified by HotGlue principal", skipped)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,8 +1,14 @@
-"""Tests for tap-side filtering of HotGlue-authored records.
+"""Tests for the CBX1 tap: keyset pagination + tap-side filtering.
 
-These tests stub the prepared HTTP request and the decorated request
-function so we exercise `request_records` end-to-end without booting
-Singer SDK auth or schema fetches.
+These stub the prepared HTTP request and the decorated request function so we
+exercise `request_records` / `get_next_page_token` / `prepare_request_payload`
+end-to-end without booting Singer SDK auth or schema fetches.
+
+Pagination is KEYSET (not offset): every request is pageNumber=0 and the
+`updatedAt` BETWEEN upper bound moves down to the previous page's minimum
+`updatedAt`. This keeps each request on the backend's ~7ms index seek instead of
+`skip(pageNumber*pageSize)`, which scanned the whole tenant partition and blew
+the 1s maxTimeMS on large orgs (HotGlue SYNC_FAILED / 500 on /CONTACT).
 """
 
 import os
@@ -11,305 +17,93 @@ from unittest.mock import MagicMock
 
 
 HOTGLUE_UUID = "d6435b86-31f9-470a-97e5-33ed6a5024d5"
+PAGE_SIZE = 10
 
 
-def _stream(*, replication_key=None, start_date=None):
-    """Minimal stream-like object for prepare_request_payload tests."""
+# --------------------------------------------------------------------------- #
+# prepare_request_payload
+# --------------------------------------------------------------------------- #
+
+def _stream(*, replication_key="updatedAt", start_date=None):
     os.environ.setdefault("BASE_URL", "http://example.invalid/")
     from tap_cbx1.client import CBX1Stream
 
     obj = SimpleNamespace()
-    obj.page_size = 10
+    obj.page_size = PAGE_SIZE
     obj.replication_key_field = replication_key
     obj.get_starting_time = lambda ctx: start_date
-    obj.prepare_request_payload = lambda ctx, tok: CBX1Stream.prepare_request_payload(
-        obj, ctx, tok
-    )
+    obj.prepare_request_payload = lambda ctx, tok: CBX1Stream.prepare_request_payload(obj, ctx, tok)
     return obj
 
 
-def _filters(stream):
-    return stream.prepare_request_payload(None, 0)["filters"]
+def _payload(stream, token=None):
+    return stream.prepare_request_payload(None, token)
 
 
-# ---- prepare_request_payload: server-side filter must be absent ----
+def test_payload_is_always_page_zero_desc():
+    """Keyset: pageNumber is pinned to 0 and sort is updatedAt DESC."""
+    p = _payload(_stream())
+    assert p["pageNumber"] == 0
+    assert p["sortBy"] == "updatedAt"
+    assert p["sortDirection"] == "DESC"
+    assert p["pageSize"] == PAGE_SIZE
+
 
 def test_payload_does_not_push_updatedby_filter_server_side(monkeypatch):
-    """Even with the env var set, the request payload must NOT carry an
-    updatedBy filter — pushing $ne updatedBy to Mongo regresses tenants
-    where HotGlue is the dominant writer (verified via prod explain)."""
+    """Even with the env var set, the payload must NOT carry an updatedBy filter —
+    pushing $ne updatedBy to Mongo regresses HotGlue-dominant tenants."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    assert "updatedBy" not in _filters(_stream())
+    assert "updatedBy" not in _payload(_stream())["filters"]
 
 
 def test_test_metadata_filter_always_present(monkeypatch):
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    assert _filters(_stream())["testMetadata"] == {"type": "EQUALS", "value": None}
+    assert _payload(_stream())["filters"]["testMetadata"] == {"type": "EQUALS", "value": None}
 
 
-def test_payload_includes_replication_key_when_set(monkeypatch):
+def test_first_page_window_has_lower_and_upper_bound():
+    """First page (token None): updatedAt BETWEEN [lower, now]."""
     from pendulum import parse
 
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    stream = _stream(replication_key="updatedAt", start_date=parse("2026-01-01T00:00:00Z"))
-    filters = _filters(stream)
-    assert filters["updatedAt"]["type"] == "BETWEEN"
-    assert "updatedBy" not in filters
+    f = _payload(_stream(start_date=parse("2026-01-01T00:00:00Z")), token=None)["filters"]
+    assert f["updatedAt"]["type"] == "BETWEEN"
+    # lower = start_date + 1ms
+    assert f["updatedAt"]["value"] == "2026-01-01T00:00:00.001000Z"
+    # upper ~ now (just assert it's a populated, later timestamp)
+    assert f["updatedAt"]["endValue"] > f["updatedAt"]["value"]
 
 
-# ---- request_records: tap-side filter ----
+def test_cursor_token_becomes_the_upper_bound():
+    """A keyset cursor token sets the BETWEEN endValue (the moving upper bound)."""
+    from pendulum import parse
 
-PAGE_SIZE = 10
+    cursor = "2026-03-15T08:30:00.123000Z"
+    f = _payload(_stream(start_date=parse("2026-01-01T00:00:00Z")), token=cursor)["filters"]
+    assert f["updatedAt"]["endValue"] == "2026-03-15T08:30:00.123000Z"
+    assert f["updatedAt"]["value"] == "2026-01-01T00:00:00.001000Z"
 
 
-def _mock_response(records, page_number, total_pages, *, last=None, slice_shape=False):
-    """Build a mocked response in the backend's Page/Slice DTO shape.
+def test_first_full_sync_defaults_lower_bound_to_epoch():
+    """No bookmark/start_date -> still a bounded BETWEEN (epoch..now) for keyset."""
+    f = _payload(_stream(start_date=None), token=None)["filters"]
+    assert f["updatedAt"]["value"] == "1970-01-01T00:00:00.000000Z"
+    assert f["updatedAt"]["endValue"] > f["updatedAt"]["value"]
 
-    `last` defaults to a realistic value derived from the page index
-    (`page_number >= total_pages - 1`) when `total_pages` is known. Pass an
-    explicit `last` to override, or `slice_shape=True` to emulate the
-    count-free backend that returns null `totalElements`/`totalPages`.
-    """
+
+# --------------------------------------------------------------------------- #
+# request_records / get_next_page_token harness
+# --------------------------------------------------------------------------- #
+
+def _rec(_id, updated_at, updated_by="other"):
+    return {"id": _id, "updatedBy": updated_by, "updatedAt": updated_at}
+
+
+def _resp(records, *, last=None, number=0, total_pages=None, slice_shape=False):
     if last is None and total_pages is not None:
-        last = page_number >= total_pages - 1
-
-    total_elements = None if slice_shape else (
-        total_pages * PAGE_SIZE if total_pages is not None else None
-    )
-    out_total_pages = None if slice_shape else total_pages
-
-    resp = MagicMock()
-    resp.json.return_value = {
-        "data": {
-            "content": records,
-            "number": page_number,
-            "size": PAGE_SIZE,
-            "first": page_number == 0,
-            "last": last,
-            "numberOfElements": len(records),
-            "empty": len(records) == 0,
-            "totalElements": total_elements,
-            "totalPages": out_total_pages,
-        }
-    }
-    return resp
-
-
-def _stream_with_pages(pages, *, slice_shape=False):
-    """Build a stream-like object whose `request_records` walks the given
-    list of (records, page_number, total_pages) tuples.
-
-    Each emitted page carries a realistic `last` flag, so pagination
-    terminates on the final page itself — no trailing fetch is required.
-    """
-    os.environ.setdefault("BASE_URL", "http://example.invalid/")
-    from tap_cbx1.client import CBX1Stream
-
-    obj = SimpleNamespace()
-    obj.logger = MagicMock()
-    obj.page_size = PAGE_SIZE
-    obj.prepare_request = lambda context, next_page_token: f"req-{next_page_token}"
-    obj.request_decorator = lambda fn: fn
-
-    iterator = iter(pages)
-    last_total_pages = pages[-1][2] if pages else 1
-
-    def _next_response(*_args, **_kwargs):
-        try:
-            return _mock_response(*next(iterator), slice_shape=slice_shape)
-        except StopIteration:
-            # Safety net: should not be reached now that the final page sets
-            # `last=True`. Emit a terminal empty page if the loop overruns.
-            return _mock_response([], last_total_pages, last_total_pages,
-                                  last=True, slice_shape=slice_shape)
-
-    obj._request = _next_response
-    obj.get_next_page_token = lambda resp, prev: (
-        CBX1Stream.get_next_page_token(obj, resp, prev)
-    )
-    obj.request_records = lambda context: CBX1Stream.request_records(obj, context)
-    return obj
-
-
-def _rec(updated_by, _id="id"):
-    return {"id": _id, "updatedBy": updated_by, "updatedAt": "2026-01-01T00:00:00.000Z"}
-
-
-def _full_page(updated_by, prefix):
-    """A full page (len == PAGE_SIZE) of identically-authored records.
-
-    Non-final pages must be full; under the count-free contract a short page
-    is itself a terminal signal, so intermediate pages carry PAGE_SIZE records.
-    """
-    return [_rec(updated_by, f"{prefix}{i}") for i in range(PAGE_SIZE)]
-
-
-def test_request_records_skips_hotglue_authored(monkeypatch):
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        ([_rec(HOTGLUE_UUID, "a"), _rec("other", "b"), _rec(HOTGLUE_UUID, "c")], 0, 1),
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert [r["id"] for r in out] == ["b"]
-
-
-def test_request_records_passthrough_when_env_unset(monkeypatch):
-    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = [
-        ([_rec(HOTGLUE_UUID, "a"), _rec("other", "b")], 0, 1),
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert [r["id"] for r in out] == ["a", "b"]
-
-
-def test_pagination_continues_across_all_filtered_page(monkeypatch):
-    """Critical: a page where every record is HotGlue must NOT stop pagination.
-    The next page is fetched regardless of how many records survived the filter."""
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        # page 0: ALL records are HotGlue — yields nothing (full page, not last)
-        (_full_page(HOTGLUE_UUID, "a"), 0, 3),
-        # page 1: also all HotGlue (full page, not last)
-        (_full_page(HOTGLUE_UUID, "d"), 1, 3),
-        # page 2: finally a non-HotGlue record (short/last page)
-        ([_rec(HOTGLUE_UUID, "f"), _rec("other", "survivor")], 2, 3),
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert [r["id"] for r in out] == ["survivor"]
-
-
-def test_pagination_terminates_when_all_pages_filtered(monkeypatch):
-    """Worst case: every page is all-HotGlue. Must yield nothing and terminate
-    cleanly (no infinite loop, no exception)."""
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        (_full_page(HOTGLUE_UUID, "a"), 0, 2),
-        ([_rec(HOTGLUE_UUID, "b")], 1, 2),  # short final page
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert out == []
-
-
-def test_pagination_handles_empty_response_page(monkeypatch):
-    """An empty content array must terminate the loop cleanly (last-page case)."""
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        ([_rec("other", "a")], 0, 1),
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert [r["id"] for r in out] == ["a"]
-
-
-def test_request_records_handles_missing_updatedby_field(monkeypatch):
-    """Records with no updatedBy stamp (e.g., legacy data) must pass through —
-    `None != hotglue_uuid` is the correct semantic."""
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        ([_rec(None, "legacy"), _rec(HOTGLUE_UUID, "skip"), _rec("other", "keep")], 0, 1),
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert [r["id"] for r in out] == ["legacy", "keep"]
-
-
-# ---- get_next_page_token: termination contract ----
-
-def _token_for(page_data):
-    """Call the real CBX1Stream.get_next_page_token against a raw `data` dict."""
-    from tap_cbx1.client import CBX1Stream
-
-    obj = SimpleNamespace()
-    obj.page_size = PAGE_SIZE
-    resp = MagicMock()
-    resp.json.return_value = {"data": page_data}
-    return CBX1Stream.get_next_page_token(obj, resp, previous_token=page_data.get("number"))
-
-
-def test_next_page_token_terminates_on_last_true_without_totalpages():
-    """Slice scenario: `last: True` with totalPages ABSENT must terminate and
-    must NOT raise TypeError (no arithmetic on a null totalPages)."""
-    # A FULL page so the short-page defensive check does not mask the `last` path.
-    page = {
-        "content": [_rec(HOTGLUE_UUID, f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 5,
-        "size": PAGE_SIZE,
-        "last": True,
-        # totalElements / totalPages intentionally absent (count-free backend)
-    }
-    assert _token_for(page) is None
-
-
-def test_next_page_token_no_typeerror_when_totalpages_null_and_last_false():
-    """Count-free backend mid-stream: last=False, totalPages=None, full page →
-    must advance (not crash) and must not compare against None."""
-    page = {
-        "content": [_rec(HOTGLUE_UUID, f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 2,
-        "size": PAGE_SIZE,
-        "last": False,
-        "totalElements": None,
-        "totalPages": None,
-    }
-    assert _token_for(page) == 3  # previous_token(2) + 1
-
-
-def test_next_page_token_terminates_on_short_page_when_last_absent():
-    """Backend omits `last` entirely: a short page (len < page_size) is the
-    terminal signal."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(3)],  # 3 < PAGE_SIZE
-        "number": 0,
-        "size": PAGE_SIZE,
-        # no `last`, no totals
-    }
-    assert _token_for(page) is None
-
-
-def test_next_page_token_terminates_on_empty_page_when_last_absent():
-    page = {"content": [], "number": 0, "size": PAGE_SIZE}
-    assert _token_for(page) is None
-
-
-def test_next_page_token_legacy_totalpages_fallback_when_last_absent():
-    """Legacy Page DTO without `last`: stop when number >= totalPages - 1, but
-    only when both are non-null. A full final page must still terminate."""
-    final = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 2,
-        "totalPages": 3,  # number(2) >= 3 - 1 → last page
-    }
-    assert _token_for(final) is None
-
-    mid = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 1,
-        "totalPages": 3,  # number(1) < 3 - 1 → more pages
-    }
-    assert _token_for(mid) == 2
-
-
-def test_next_page_token_advances_on_full_page_current_backend():
-    """Current backend: full page, last=False, totalPages present → advance."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 0,
-        "last": False,
-        "totalElements": 30,
-        "totalPages": 3,
-    }
-    assert _token_for(page) == 1
-
-
-# ---- CROSS-REPO CONTRACT / E2E: tap <-> backend handshake, both versions ----
-
-def _page_json(records, number, total_pages, *, slice_shape):
-    """Emit one page in the EXACT backend JSON shape.
-
-    slice_shape=False → legacy Page DTO (totalElements/totalPages populated).
-    slice_shape=True  → count-free Slice DTO (totalElements/totalPages null).
-    Both shapes always carry `last`.
-    """
-    last = number >= total_pages - 1
-    return {
+        last = number >= total_pages - 1
+    total_elements = None if slice_shape else (total_pages * PAGE_SIZE if total_pages is not None else None)
+    out = MagicMock()
+    out.json.return_value = {
         "data": {
             "content": records,
             "number": number,
@@ -318,125 +112,227 @@ def _page_json(records, number, total_pages, *, slice_shape):
             "last": last,
             "numberOfElements": len(records),
             "empty": len(records) == 0,
-            "totalElements": None if slice_shape else total_pages * PAGE_SIZE,
+            "totalElements": total_elements,
             "totalPages": None if slice_shape else total_pages,
         }
     }
+    return out
 
 
-def _e2e_stream(page_jsons, *, max_iterations=50):
-    """Drive the REAL request_records over a mocked transport that returns the
-    given sequence of raw page JSON dicts. The transport itself emits the JSON;
-    we do NOT bypass get_next_page_token. Iteration is capped to fail loudly on
-    a runaway loop instead of hanging.
-    """
+def _stream_with_responses(responses, *, max_iterations=50):
+    """Drive the REAL request_records / get_next_page_token over a transport that
+    returns the queued responses in order. The transport ignores the cursor (we
+    assert the yield/dedup/termination behaviour, not server-side filtering)."""
     os.environ.setdefault("BASE_URL", "http://example.invalid/")
     from tap_cbx1.client import CBX1Stream
 
     obj = SimpleNamespace()
     obj.logger = MagicMock()
     obj.page_size = PAGE_SIZE
-    obj.prepare_request = lambda context, next_page_token: f"req-{next_page_token}"
+    obj.replication_key_field = "updatedAt"
+    obj.prepare_request = lambda context, next_page_token: f"req::{next_page_token}"
     obj.request_decorator = lambda fn: fn
 
     state = {"calls": 0}
 
-    def _transport(*_args, **_kwargs):
+    def _transport(*_a, **_k):
         idx = state["calls"]
         state["calls"] += 1
         if state["calls"] > max_iterations:
             raise AssertionError("pagination did not terminate (runaway loop)")
-        # Real transport returns a response object exposing .json()
-        payload = page_jsons[idx] if idx < len(page_jsons) else page_jsons[-1]
-        resp = MagicMock()
-        resp.json.return_value = payload
-        return resp
+        return responses[idx] if idx < len(responses) else responses[-1]
 
     obj._request = _transport
-    obj.get_next_page_token = lambda resp, prev: CBX1Stream.get_next_page_token(
-        obj, resp, prev
-    )
+    obj.get_next_page_token = lambda resp, prev: CBX1Stream.get_next_page_token(obj, resp, prev)
     obj.request_records = lambda context: CBX1Stream.request_records(obj, context)
     return obj, state
 
 
-def _three_page_sequence(slice_shape):
-    """3 pages, 10 + 10 + 4 = 24 records; final page short. Both shapes set
-    `last` on page 2."""
-    total_pages = 3
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], 0, total_pages, slice_shape=slice_shape)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], 1, total_pages, slice_shape=slice_shape)
-    p2 = _page_json([_rec("other", f"p2-{i}") for i in range(4)], 2, total_pages, slice_shape=slice_shape)
-    return [p0, p1, p2]
+def _full(prefix, ts):
+    """A full page (len == PAGE_SIZE) of records all at timestamp `ts`."""
+    return [_rec(f"{prefix}{i}", ts) for i in range(PAGE_SIZE)]
 
 
-def test_e2e_contract_legacy_page_shape(monkeypatch):
-    """(a) Legacy Page shape: totals populated. Loop yields ALL 24 records,
-    terminates, no exception."""
+# ---- happy path: walk the cursor across pages -----------------------------
+
+def test_keyset_walks_all_pages_distinct_timestamps(monkeypatch):
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = _three_page_sequence(slice_shape=False)
-    # Sanity: this fixture really is the legacy shape.
-    assert pages[0]["data"]["totalPages"] == 3
-    assert pages[0]["data"]["totalElements"] == 30
-
-    stream, state = _e2e_stream(pages)
-    out = list(stream.request_records(context=None))
-    assert [r["id"] for r in out] == (
-        [f"p0-{i}" for i in range(PAGE_SIZE)]
-        + [f"p1-{i}" for i in range(PAGE_SIZE)]
-        + [f"p2-{i}" for i in range(4)]
-    )
-    assert len(out) == 24
-    assert state["calls"] == 3  # exactly 3 fetches, no trailing probe
-
-
-def test_e2e_contract_count_free_slice_shape(monkeypatch):
-    """(b) New count-free Slice shape: totalElements/totalPages NULL, `last`
-    drives termination. Same 24 records, terminates, no exception/TypeError."""
-    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = _three_page_sequence(slice_shape=True)
-    # Sanity: this fixture really is the count-free shape.
-    assert pages[0]["data"]["totalPages"] is None
-    assert pages[0]["data"]["totalElements"] is None
-    assert pages[2]["data"]["last"] is True
-
-    stream, state = _e2e_stream(pages)
+    # 3 full pages, strictly-descending timestamps (no boundary ties), final short page.
+    responses = [
+        _resp([_rec(f"p0-{i}", f"2026-03-03T00:00:{59-i:02d}.000Z") for i in range(PAGE_SIZE)], total_pages=3, number=0),
+        _resp([_rec(f"p1-{i}", f"2026-03-02T00:00:{59-i:02d}.000Z") for i in range(PAGE_SIZE)], total_pages=3, number=0),
+        _resp([_rec(f"p2-{i}", f"2026-03-01T00:00:{59-i:02d}.000Z") for i in range(4)], total_pages=3, number=0),
+    ]
+    stream, state = _stream_with_responses(responses)
     out = list(stream.request_records(context=None))
     assert len(out) == 24
-    assert [r["id"] for r in out][0] == "p0-0"
-    assert [r["id"] for r in out][-1] == "p2-3"
+    assert out[0]["id"] == "p0-0" and out[-1]["id"] == "p2-3"
     assert state["calls"] == 3
 
 
-def test_e2e_contract_slice_full_final_page_with_last_true(monkeypatch):
-    """Count-free edge: the final page is FULL (len == page_size) but carries
-    `last: True`. Termination must come from `last`, not the short-page check."""
+def test_keyset_terminates_on_last_true_full_page(monkeypatch):
+    """Count-free Slice: a FULL final page with last=True and null totalPages must
+    terminate via `last` (no TypeError, no extra fetch)."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    total_pages = 2
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], 0, total_pages, slice_shape=True)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], 1, total_pages, slice_shape=True)
-    assert p1["data"]["last"] is True and len(p1["data"]["content"]) == PAGE_SIZE
-    assert p1["data"]["totalPages"] is None  # would TypeError under old logic
-
-    stream, state = _e2e_stream([p0, p1])
+    responses = [
+        _resp(_full("a", "2026-03-03T00:00:01.000Z"), last=False, slice_shape=True),
+        _resp(_full("b", "2026-03-02T00:00:01.000Z"), last=True, slice_shape=True),
+    ]
+    stream, state = _stream_with_responses(responses)
     out = list(stream.request_records(context=None))
     assert len(out) == 2 * PAGE_SIZE
-    assert state["calls"] == 2  # full final page still stops via `last`
+    assert state["calls"] == 2
 
 
-# ---- bookmark signpost ----
+# ---- boundary de-dup (inclusive cursor) -----------------------------------
 
-def test_replication_key_signpost_returns_now_not_none():
-    """When 0 records are yielded (e.g., all-HotGlue tenant), state must still
-    advance. Singer SDK caps state at the signpost; returning a fresh "now"
-    moves the bookmark forward even when nothing yielded."""
-    from datetime import datetime, timezone
+def test_keyset_dedups_inclusive_boundary_record(monkeypatch):
+    """The inclusive upper bound re-returns the boundary record on the next page;
+    it must be emitted exactly once."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    boundary = _rec("BORDER", "2026-03-02T00:00:00.000Z")
+    page0 = [_rec(f"p0-{i}", f"2026-03-03T00:00:{59-i:02d}.000Z") for i in range(PAGE_SIZE - 1)] + [boundary]
+    # page1 cursor == boundary.updatedAt; backend re-includes BORDER, then older rows.
+    page1 = [dict(boundary)] + [_rec(f"p1-{i}", f"2026-03-01T00:00:{59-i:02d}.000Z") for i in range(3)]
+    stream, _ = _stream_with_responses([
+        _resp(page0, total_pages=2, number=0),
+        _resp(page1, total_pages=2, number=0),
+    ])
+    out = [r["id"] for r in stream.request_records(context=None)]
+    assert out.count("BORDER") == 1                      # emitted once, not twice
+    assert out[:PAGE_SIZE][-1] == "BORDER"
+    assert "p1-0" in out
 
+
+def test_keyset_keeps_unseen_tie_member_at_boundary(monkeypatch):
+    """A second record sharing the boundary updatedAt that we have NOT seen yet
+    must still be emitted (no data loss from the dedup)."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    ts = "2026-03-02T00:00:00.000Z"
+    seen = _rec("SEEN", ts)
+    page0 = [_rec(f"p0-{i}", f"2026-03-03T00:00:{59-i:02d}.000Z") for i in range(PAGE_SIZE - 1)] + [seen]
+    # next page re-includes SEEN (dedup) AND a tie partner UNSEEN at the same ts.
+    page1 = [dict(seen), _rec("UNSEEN", ts)] + [_rec(f"p1-{i}", f"2026-03-01T00:00:{59-i:02d}.000Z") for i in range(2)]
+    stream, _ = _stream_with_responses([
+        _resp(page0, total_pages=2, number=0),
+        _resp(page1, total_pages=2, number=0),
+    ])
+    out = [r["id"] for r in stream.request_records(context=None)]
+    assert out.count("SEEN") == 1
+    assert "UNSEEN" in out
+
+
+# ---- no-progress guard -----------------------------------------------------
+
+def test_keyset_no_progress_guard_stops(monkeypatch):
+    """Pathological: two full pages all sharing one updatedAt cannot advance an
+    updatedAt-only cursor. Must stop (no infinite loop) and warn."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    same = "2026-03-02T00:00:00.000Z"
+    stream, state = _stream_with_responses([
+        _resp(_full("a", same), last=False, slice_shape=True),
+        _resp(_full("b", same), last=False, slice_shape=True),
+    ])
+    out = list(stream.request_records(context=None))
+    assert state["calls"] == 2          # bailed, did not loop forever
+    assert len(out) == 2 * PAGE_SIZE     # both fetched pages were emitted
+    assert stream.logger.warning.called
+
+
+# ---- tap-side HotGlue-author filtering (preserved behaviour) ---------------
+
+def test_request_records_skips_hotglue_authored(monkeypatch):
+    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
+    page = [_rec("a", "2026-03-03T00:00:03.000Z", HOTGLUE_UUID),
+            _rec("b", "2026-03-03T00:00:02.000Z", "other"),
+            _rec("c", "2026-03-03T00:00:01.000Z", HOTGLUE_UUID)]
+    stream, _ = _stream_with_responses([_resp(page, last=True)])
+    out = [r["id"] for r in stream.request_records(context=None)]
+    assert out == ["b"]
+
+
+def test_pagination_continues_across_all_filtered_page(monkeypatch):
+    """A page where every record is HotGlue-authored must NOT stop pagination."""
+    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
+    responses = [
+        _resp([_rec(f"a{i}", f"2026-03-03T00:00:{59-i:02d}.000Z", HOTGLUE_UUID) for i in range(PAGE_SIZE)], total_pages=3, number=0),
+        _resp([_rec(f"d{i}", f"2026-03-02T00:00:{59-i:02d}.000Z", HOTGLUE_UUID) for i in range(PAGE_SIZE)], total_pages=3, number=0),
+        _resp([_rec("f", "2026-03-01T00:00:02.000Z", HOTGLUE_UUID), _rec("survivor", "2026-03-01T00:00:01.000Z", "other")], total_pages=3, number=0),
+    ]
+    stream, _ = _stream_with_responses(responses)
+    out = [r["id"] for r in stream.request_records(context=None)]
+    assert out == ["survivor"]
+
+
+def test_request_records_handles_missing_updatedby_field(monkeypatch):
+    """Records with no updatedBy stamp must pass through (None != hotglue uuid)."""
+    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
+    page = [_rec("legacy", "2026-03-03T00:00:03.000Z", None),
+            _rec("skip", "2026-03-03T00:00:02.000Z", HOTGLUE_UUID),
+            _rec("keep", "2026-03-03T00:00:01.000Z", "other")]
+    stream, _ = _stream_with_responses([_resp(page, last=True)])
+    out = [r["id"] for r in stream.request_records(context=None)]
+    assert out == ["legacy", "keep"]
+
+
+def test_request_records_handles_empty_page(monkeypatch):
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    stream, state = _stream_with_responses([_resp([], last=True)])
+    assert list(stream.request_records(context=None)) == []
+    assert state["calls"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# get_next_page_token: cursor + termination contract
+# --------------------------------------------------------------------------- #
+
+def _token_for(page_data):
     from tap_cbx1.client import CBX1Stream
 
     obj = SimpleNamespace()
-    signpost = CBX1Stream.get_replication_key_signpost(obj, context=None)
+    obj.page_size = PAGE_SIZE
+    obj.replication_key_field = "updatedAt"
+    resp = MagicMock()
+    resp.json.return_value = {"data": page_data}
+    return CBX1Stream.get_next_page_token(obj, resp, previous_token=None)
+
+
+def test_token_is_min_updatedat_on_full_page():
+    """A full page returns the last (minimum, DESC) record's updatedAt as cursor."""
+    recs = [_rec(f"x{i}", f"2026-03-03T00:00:{59-i:02d}.000Z") for i in range(PAGE_SIZE)]
+    page = {"content": recs, "number": 0, "last": False, "totalPages": 5}
+    assert _token_for(page) == recs[-1]["updatedAt"]
+
+
+def test_token_none_on_last_true_full_page():
+    recs = _full("x", "2026-03-03T00:00:01.000Z")
+    page = {"content": recs, "number": 5, "last": True}  # totalPages absent (slice)
+    assert _token_for(page) is None
+
+
+def test_token_none_on_short_page():
+    page = {"content": [_rec(f"x{i}", "2026-03-03T00:00:01.000Z") for i in range(3)], "number": 0}
+    assert _token_for(page) is None
+
+
+def test_token_none_on_empty_page():
+    assert _token_for({"content": [], "number": 0}) is None
+
+
+def test_token_legacy_totalpages_fallback():
+    recs = _full("x", "2026-03-03T00:00:01.000Z")
+    assert _token_for({"content": recs, "number": 2, "totalPages": 3}) is None        # 2 >= 3-1
+    assert _token_for({"content": recs, "number": 0, "totalPages": 3}) == recs[-1]["updatedAt"]
+
+
+# --------------------------------------------------------------------------- #
+# bookmark signpost
+# --------------------------------------------------------------------------- #
+
+def test_replication_key_signpost_returns_now_not_none():
+    from datetime import datetime, timezone
+    from tap_cbx1.client import CBX1Stream
+
+    signpost = CBX1Stream.get_replication_key_signpost(SimpleNamespace(), context=None)
     assert signpost is not None
-    # pendulum DateTime is a subclass of datetime; should be tz-aware and "now-ish".
-    delta = abs((datetime.now(timezone.utc) - signpost).total_seconds())
-    assert delta < 5
+    assert abs((datetime.now(timezone.utc) - signpost).total_seconds()) < 5


### PR DESCRIPTION
## Problem

Prod HotGlue **CBX1 → HubSpot (Sync Accounts and Contacts)** fails with `SYNC_FAILED`:
```
singer_sdk.exceptions.RetriableAPIError: 500 Server Error: for path: /CONTACT
Giving up _request(...) after 5 tries
```

## Root cause (verified against prod, read-only)

The tap paginated by **offset**: `prepare_request_payload` sent `pageNumber = next_page_token` and `get_next_page_token` returned `previous_token + 1`, so the backend ran `skip(pageNumber × pageSize)`. The `(orgId, deletedAt, updatedAt)` index already exists and is used — `explain()` on the egestion query confirms it. **Offset is the problem, not the index:**

| egestion query (org with 198,370 live contacts) | plan | time | keysExamined |
|---|---|---|---|
| page 1 (`skip 0`) | `IXSCAN orgId_deletedAt_idx_updatedAt_desc` | **6 ms** | 100 |
| `skip 50,000` | IXSCAN + **SKIP** | **5,573 ms** | 50,100 |
| `skip 150,000` | IXSCAN + **SKIP** | **13,779 ms** | 150,100 |

The backend caps queries at **1 s** (`maxTimeMS`). At `page_size=10` a full sync of this org is ~19,837 pages; past ~page 900 (`skip ≈ 9,000`) every page exceeds 1 s → 500 → singer retries 5× and gives up → `SYNC_FAILED`. (It surfaces as a Mongo *multiplanner* timeout because 12 `orgId`-prefixed candidate indexes all stall in the skip during plan trial.)

## Fix — keyset (cursor) pagination

Every request stays on **page 0**; the `updatedAt` BETWEEN **upper bound** moves down to the previous page's minimum `updatedAt` (records are sorted `updatedAt DESC`). That's an index range seek — **verified 7 ms regardless of depth** vs 64 s for a naive `(updatedAt,_id)` compound cursor on the current index, so we deliberately keyset on `updatedAt` only.

- Inclusive upper bound; the boundary record(s) are **de-duplicated by id** so nothing is emitted twice and no tie member is lost (largest same-`updatedAt` group in prod = 2).
- **No-progress guard**: if a full page shares one `updatedAt` (would stall an `updatedAt`-only cursor) the tap stops with a warning instead of looping. Pathological only; real data never hits it.
- `page_size 10 → 100`: pure round-trip reduction, no skip cost now.
- Termination contract (`data.last` / short page, count-free Slice compatible) is unchanged.

## Tests

`tests/test_filters.py` rewritten for the keyset contract — cursor advance across pages, boundary de-dup (no double-emit; unseen tie member still emitted), no-progress guard, `last`/short/empty termination, and the preserved HotGlue-author tap-side filter. **21 passing** locally (py3.10 / singer-sdk 0.4.3).

## Rollout / mitigation

No backend change required. To unblock the affected tenant immediately before this deploys, advance its replication bookmark to a recent `updatedAt` so the next run pulls only the small recent delta (page-0, milliseconds) instead of the historical backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)