### PR TITLE
feat(tap): keyset/cursor pagination (drop pageNumber)

### DIFF
--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -11,9 +11,21 @@ from singer import StateMessage
 from tap_cbx1.auth import TapCBX1Auth
 from tap_cbx1.schema_utils import fetch_schema_from_api
 from datetime import timedelta
-from tap_cbx1.constants import CRM_KEY, HOTGLUE_PRINCIPAL_ID_ENV
+from tap_cbx1.constants import (
+    CRM_KEY,
+    HOTGLUE_PRINCIPAL_ID_ENV,
+    PAGE_SIZE_KEY,
+    DEFAULT_PAGE_SIZE,
+)
 
 _TToken = TypeVar("_TToken")
+
+# Extra Singer-state bookmark fields (alongside the SDK's replication_key_value).
+# Persisting these makes intra-run keyset progress durable: a run that ends partway
+# leaves a resume point so the next run reads strictly the unread remainder.
+_CURSOR_STATE_KEY = "cursor"
+_WINDOW_END_STATE_KEY = "window_end"
+_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class CBX1Stream(RESTStream):
@@ -26,58 +38,108 @@ class CBX1Stream(RESTStream):
     def url_base(self):
         return os.getenv("BASE_URL") + "api/t/v1/targets/integrations"
 
-    page_size = 10
     rest_method = "POST"
     replication_key_field = "updatedAt"
+
+    @property
+    def page_size(self) -> int:
+        """Records per page, configurable via the ``page_size`` setting.
+
+        Keyset pagination has no per-page ``skip`` cost, so a larger page is not
+        more expensive on the backend — it simply cuts the number of round-trips
+        (200k records: ~400 requests at 500 vs ~20k at 10). Falls back to
+        ``DEFAULT_PAGE_SIZE`` on a missing/invalid value.
+        """
+        try:
+            return int(self.config.get(PAGE_SIZE_KEY, DEFAULT_PAGE_SIZE))
+        except (TypeError, ValueError):
+            return DEFAULT_PAGE_SIZE
 
     @property
     def authenticator(self) -> TapCBX1Auth:
         """Return a new authenticator object."""
         return TapCBX1Auth.create_for_stream(self)
 
+    def _resume_state(self):
+        """Resolve ``(initial_token, pinned_window_end)`` for THIS run, memoized once.
+
+        Resumes from a persisted ``(cursor, window_end)`` pair when BOTH are present
+        (a prior run ended partway); otherwise starts a fresh window whose upper
+        bound is pinned at ``now()``.
+
+        The window upper bound is PINNED and reused on resume on purpose: the sort
+        is DESC (newest -> oldest), so recomputing ``now()`` on a resume run would
+        let records that arrived between runs slip in at the top of the window and
+        be skipped. Any half-written resume state (a cursor without a window_end) is
+        discarded and treated as a fresh window.
+        """
+        if getattr(self, "_resume_cache", None) is None:
+            state = self.stream_state
+            saved_cursor = state.get(_CURSOR_STATE_KEY)
+            saved_window_end = state.get(_WINDOW_END_STATE_KEY)
+            if saved_cursor and saved_window_end:
+                self._resume_cache = (saved_cursor, parse(saved_window_end))
+            else:
+                state.pop(_CURSOR_STATE_KEY, None)
+                state.pop(_WINDOW_END_STATE_KEY, None)
+                self._resume_cache = ("", parse("now"))
+        return self._resume_cache
+
     def get_next_page_token(
             self, response: requests.Response, previous_token: Optional[Any]
     ) -> Optional[Any]:
-        """Return the next keyset cursor or None when there are no more pages.
+        """Return the next keyset cursor, ``None`` on clean completion, or raise.
 
         Uses keyset (cursor) pagination, NOT page-number/skip pagination.
 
-        WHY: with skip-based paging the backend computes ``skip =
-        pageNumber * pageSize`` and Mongo must walk every one of those skipped
-        index entries on every page request. On a large org the deep pages
-        therefore cost progressively more and pin the prod primary — a
-        ``CM100`` query timeout / CPU spike. The cursor is the backend's opaque
-        ``(updatedAt, id)`` keyset token: each page seeks directly to its
-        starting key, so every page costs the same regardless of how deep into
-        the result set we are. The compound ``id`` tiebreaker is required
-        because Mongo stores ``updatedAt`` at millisecond precision and a bulk
-        write shares a single millisecond across many documents — without the
-        ``id`` component the cursor could skip or repeat records that share an
-        ``updatedAt`` value.
+        WHY keyset: with skip-based paging the backend computes ``skip =
+        pageNumber * pageSize`` and Mongo walks every skipped index entry on every
+        page, so deep pages cost progressively more and pin the prod primary (a
+        ``CM100`` query timeout / CPU spike). The cursor is the backend's opaque
+        ``(updatedAt, id)`` keyset token: each page seeks directly to its starting
+        key, so every page costs the same regardless of depth. The compound ``id``
+        tiebreaker is required because Mongo stores ``updatedAt`` at millisecond
+        precision and a bulk write shares one millisecond across many documents.
 
-        Termination: the backend says this is the final page (``last`` is
-        True), it returns no further cursor (``cursor`` missing/empty — also
-        the signal from a non-keyset / older backend), or the page is short
-        (``len(content) < page_size``).
+        Returns:
+            - ``None`` for a clean end of the window: the backend flags ``last``,
+              or returns a short page (``len(content) < page_size``).
+            - the next ``cursor`` token when a full page reports more data.
+
+        Raises:
+            RuntimeError: a full page reports it is NOT the last page yet carries no
+                cursor. Terminating here would let the bookmark advance to ~now()
+                and silently drop the unread older tail — the signature of an
+                older/non-keyset backend (rolling deploy / rollback). Fail loudly so
+                the run does not record false progress; deploy the keyset backend
+                first.
         """
         page_data = response.json().get('data') or {}
+        content = page_data.get('content') or []
 
         # Primary signal: the backend says this is the final page.
         if page_data.get('last') is True:
             return None
 
-        # The opaque keyset cursor for the next page. Missing/empty means the
-        # backend has no more pages (or is a non-keyset / older backend).
         cursor = page_data.get('cursor')
-        if not cursor:
-            return None
+        if cursor:
+            # A short page alongside a cursor still means nothing follows it.
+            if len(content) < self.page_size:
+                return None
+            return cursor
 
-        # Defensive: a short or empty page means there is nothing after it.
-        content = page_data.get('content') or []
+        # No cursor and not flagged last: a short/empty page means we are done
+        # (e.g. a legacy short final page); a FULL page means the backend cannot
+        # hand us a resume point even though more data exists -> fail loudly.
         if len(content) < self.page_size:
             return None
 
-        return cursor
+        raise RuntimeError(
+            f"Egestion list returned a full page (size {len(content)}) with no "
+            "keyset `cursor` and `last` != true. Refusing to terminate silently — "
+            "that would drop the unread remainder of the window. Is the backend on "
+            "the keyset-cursor build?"
+        )
 
     def get_starting_time(self, context):
         start_date = self.config.get("start_date")
@@ -86,12 +148,11 @@ class CBX1Stream(RESTStream):
         rep_key = self.get_starting_timestamp(context)
         return rep_key or start_date
 
-
     def get_url(self, context: dict | None) -> str:
         crm = self.config.get(CRM_KEY)
         url = "".join([self.url_base, self.path or "", f"/{crm}/list"])
         return url
-    
+
     def get_url_params(
             self,
             context: dict | None,
@@ -106,6 +167,7 @@ class CBX1Stream(RESTStream):
             next_page_token: _TToken | None,
     ) -> dict | None:
         start_date = self.get_starting_time(context)
+        _, window_end = self._resume_state()
 
         # Keyset pagination: send the opaque cursor, never a pageNumber/skip.
         # An empty-string cursor on the first page signals keyset mode to the
@@ -128,12 +190,15 @@ class CBX1Stream(RESTStream):
         if self.replication_key_field and start_date:
             # Increment start date by 1 millisecond
             start_date = start_date + timedelta(milliseconds=1)
-            iso_start_date = start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            iso_now = parse("now").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            iso_start_date = start_date.strftime(_ISO_FORMAT)
+            # PINNED window upper bound (not a fresh now()): resume runs reuse the
+            # same endValue so a DESC scan cannot skip records that arrived between
+            # runs. See _resume_state.
+            iso_window_end = window_end.strftime(_ISO_FORMAT)
             filters[self.replication_key_field] = {
                 "type": "BETWEEN",
                 "value": iso_start_date,
-                "endValue": iso_now
+                "endValue": iso_window_end
             }
 
         payload["filters"] = filters
@@ -144,9 +209,43 @@ class CBX1Stream(RESTStream):
         result = self._http_headers
         return result
 
+    def _increment_stream_state(self, latest_record, *, context=None) -> None:
+        """Disabled: the run-to-run watermark is advanced manually (request_records).
+
+        The SDK's record-driven high-watermark assumes ASCENDING replication-key
+        order and finalizes on ANY clean generator return. Our egestion read is
+        DESC (newest first), so letting it run would commit the NEWEST updatedAt
+        (seen on page 1) as the bookmark on a partial run and then silently skip the
+        unread older tail. We instead advance ``replication_key_value`` only on
+        confirmed window completion.
+        """
+        return None
+
+    def get_replication_key_signpost(self, context: Optional[dict]) -> Optional[Any]:
+        """No signpost — watermark advancement is manual (see _increment_stream_state).
+
+        With auto-increment disabled the signpost would be inert anyway; returning
+        None keeps the state clean. Window completion advances the bookmark to the
+        pinned window upper bound even when zero records were yielded.
+        """
+        return None
+
     def request_records(self, context: dict | None) -> Iterable[dict]:
-        # Empty cursor ⇒ first keyset page (signals keyset mode to the backend).
-        next_page_token = ""
+        """Yield records for the pinned window, persisting a durable keyset cursor.
+
+        Forward progress is durable across runs: after every page's records have
+        been emitted, the next-page cursor and the pinned window upper bound are
+        written to Singer state. If the run ends partway (transport error, OOM, wall
+        clock), the next run resumes from that cursor against the same window and
+        reads only the unread remainder — no record skipped or duplicated. On clean
+        completion the run-to-run ``updatedAt`` bookmark is advanced to the pinned
+        upper bound and the cursor is cleared, so the next run starts a fresh window.
+        """
+        token, window_end = self._resume_state()
+        window_end_iso = window_end.strftime(_ISO_FORMAT)
+        replication_key = self.replication_key or self.replication_key_field
+        state = self.stream_state
+
         decorated_request = self.request_decorator(self._request)
         finished = False
         # Tap-side filter: drop records HotGlue itself last-modified to avoid re-ingesting our own
@@ -155,20 +254,39 @@ class CBX1Stream(RESTStream):
         skipped = 0
 
         while not finished:
-            prepared_request = self.prepare_request(
-                context,
-                next_page_token=next_page_token
-            )
+            prepared_request = self.prepare_request(context, next_page_token=token)
             resp = decorated_request(prepared_request, context)
-            response_content = resp.json().get('data').get('content')
-            for content in response_content:
-                if hotglue_principal_id and content.get("updatedBy") == hotglue_principal_id:
+            content = (resp.json().get('data') or {}).get('content') or []
+
+            # Classify the response BEFORE emitting: an incompatible/unsafe page
+            # (full page, not last, no cursor) raises here so its records are never
+            # emitted and the run fails without recording false progress.
+            next_token = self.get_next_page_token(resp, token)
+
+            for record in content:
+                if hotglue_principal_id and record.get("updatedBy") == hotglue_principal_id:
                     skipped += 1
                     continue
-                yield content
+                yield record
 
-            next_page_token = self.get_next_page_token(resp, next_page_token)
-            finished = next_page_token is None
+            # Every record for this page has now been emitted by the SDK, so it is
+            # safe to advance the persisted resume point past this page.
+            if next_token is None:
+                # Window complete: advance the run-to-run watermark to the pinned
+                # upper bound and clear the intra-run cursor.
+                state["replication_key"] = replication_key
+                state["replication_key_value"] = window_end_iso
+                state.pop(_CURSOR_STATE_KEY, None)
+                state.pop(_WINDOW_END_STATE_KEY, None)
+                self._write_state_message()
+                finished = True
+            else:
+                # Persist the resume point (cursor + pinned window) WITHOUT advancing
+                # the run-to-run watermark.
+                state[_CURSOR_STATE_KEY] = next_token
+                state[_WINDOW_END_STATE_KEY] = window_end_iso
+                self._write_state_message()
+                token = next_token
 
         if hotglue_principal_id and skipped:
             self.logger.info("Skipped %d records last-modified by HotGlue principal", skipped)
@@ -184,27 +302,20 @@ class CBX1Stream(RESTStream):
 
         singer.write_message(StateMessage(value=tap_state))
 
-    def get_replication_key_signpost(self, context: Optional[dict]) -> Optional[Any]:
-        # Cap state advancement at "now" so a sync that yields zero records
-        # (e.g., every record in the window was HotGlue-authored and filtered
-        # out tap-side) still moves the bookmark forward instead of replaying
-        # the same window on the next run.
-        return parse("now")
-
     def get_schema(self) -> dict:
         """Get schema dynamically from CBX1 API."""
         if not self.target_name:
             raise ValueError(f"target_name must be set for {self.__class__.__name__}")
-        
+
         headers = {}
         if self.authenticator:
             headers.update(self.authenticator.auth_headers or {})
-        
+
         schema = fetch_schema_from_api(self.url_base, self.target_name,self.config.get(CRM_KEY), headers)
-        
+
         if schema is None:
             raise RuntimeError(f"Failed to fetch schema for target {self.target_name}")
-        
+
         return schema
 
     @cached_property

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -13,7 +13,7 @@ from tap_cbx1.schema_utils import fetch_schema_from_api
 from datetime import timedelta
 from tap_cbx1.constants import (
     CRM_KEY,
-    HOTGLUE_PRINCIPAL_ID_ENV,
+    HOTGLUE_PRINCIPAL_ID,
     PAGE_SIZE_KEY,
     DEFAULT_PAGE_SIZE,
 )
@@ -250,7 +250,7 @@ class CBX1Stream(RESTStream):
         finished = False
         # Tap-side filter: drop records HotGlue itself last-modified to avoid re-ingesting our own
         # writes. Pushed-down `$ne updatedBy` regresses Mongo on tenants where HotGlue dominates.
-        hotglue_principal_id = os.getenv(HOTGLUE_PRINCIPAL_ID_ENV)
+        hotglue_principal_id = os.getenv(HOTGLUE_PRINCIPAL_ID)
         skipped = 0
 
         while not finished:

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -38,38 +38,46 @@ class CBX1Stream(RESTStream):
     def get_next_page_token(
             self, response: requests.Response, previous_token: Optional[Any]
     ) -> Optional[Any]:
-        """Return a token for identifying next page or None if no more pages.
+        """Return the next keyset cursor or None when there are no more pages.
 
-        Terminates on ``data.last`` (a boolean the backend already returns)
-        rather than ``data.totalPages``. Computing ``totalPages`` forces the
-        backend to run a per-page full-partition Mongo ``count()`` which drives
-        the prod primary to ~94% CPU; the count-free backend therefore returns
-        ``null`` for ``totalElements``/``totalPages`` while still sending
-        ``last``. We never do arithmetic on a possibly-null ``totalPages``.
+        Uses keyset (cursor) pagination, NOT page-number/skip pagination.
+
+        WHY: with skip-based paging the backend computes ``skip =
+        pageNumber * pageSize`` and Mongo must walk every one of those skipped
+        index entries on every page request. On a large org the deep pages
+        therefore cost progressively more and pin the prod primary — a
+        ``CM100`` query timeout / CPU spike. The cursor is the backend's opaque
+        ``(updatedAt, id)`` keyset token: each page seeks directly to its
+        starting key, so every page costs the same regardless of how deep into
+        the result set we are. The compound ``id`` tiebreaker is required
+        because Mongo stores ``updatedAt`` at millisecond precision and a bulk
+        write shares a single millisecond across many documents — without the
+        ``id`` component the cursor could skip or repeat records that share an
+        ``updatedAt`` value.
+
+        Termination: the backend says this is the final page (``last`` is
+        True), it returns no further cursor (``cursor`` missing/empty — also
+        the signal from a non-keyset / older backend), or the page is short
+        (``len(content) < page_size``).
         """
-        previous_token = previous_token or 0
         page_data = response.json().get('data') or {}
-        content = page_data.get('content') or []
 
         # Primary signal: the backend says this is the final page.
-        # Works for both the current Page DTO and the future count-free Slice.
         if page_data.get('last') is True:
             return None
 
+        # The opaque keyset cursor for the next page. Missing/empty means the
+        # backend has no more pages (or is a non-keyset / older backend).
+        cursor = page_data.get('cursor')
+        if not cursor:
+            return None
+
         # Defensive: a short or empty page means there is nothing after it.
-        # Handles a backend that omits `last` entirely.
+        content = page_data.get('content') or []
         if len(content) < self.page_size:
             return None
 
-        # Legacy fallback ONLY when `last` is absent: stop on the last page by
-        # index. Never compare when totalPages is None (would TypeError).
-        if page_data.get('last') is None:
-            number = page_data.get('number')
-            total_pages = page_data.get('totalPages')
-            if number is not None and total_pages is not None and number >= total_pages - 1:
-                return None
-
-        return previous_token + 1
+        return cursor
 
     def get_starting_time(self, context):
         start_date = self.config.get("start_date")
@@ -99,8 +107,11 @@ class CBX1Stream(RESTStream):
     ) -> dict | None:
         start_date = self.get_starting_time(context)
 
+        # Keyset pagination: send the opaque cursor, never a pageNumber/skip.
+        # An empty-string cursor on the first page signals keyset mode to the
+        # backend; subsequent pages echo back the token the backend returned.
         payload = {
-            "pageNumber": next_page_token,
+            "cursor": next_page_token if next_page_token is not None else "",
             "pageSize": self.page_size,
             "sortBy": self.replication_key_field,
             "sortDirection": "DESC",
@@ -134,7 +145,8 @@ class CBX1Stream(RESTStream):
         return result
 
     def request_records(self, context: dict | None) -> Iterable[dict]:
-        next_page_token = 0
+        # Empty cursor ⇒ first keyset page (signals keyset mode to the backend).
+        next_page_token = ""
         decorated_request = self.request_decorator(self._request)
         finished = False
         # Tap-side filter: drop records HotGlue itself last-modified to avoid re-ingesting our own

--- a/tap_cbx1/client.py
+++ b/tap_cbx1/client.py
@@ -23,8 +23,8 @@ _TToken = TypeVar("_TToken")
 # Extra Singer-state bookmark fields (alongside the SDK's replication_key_value).
 # Persisting these makes intra-run keyset progress durable: a run that ends partway
 # leaves a resume point so the next run reads strictly the unread remainder.
-_CURSOR_STATE_KEY = "cursor"
-_WINDOW_END_STATE_KEY = "window_end"
+CURSOR_STATE_KEY = "cursor"
+WINDOW_END_STATE_KEY = "window_end"
 _ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
@@ -75,13 +75,13 @@ class CBX1Stream(RESTStream):
         """
         if getattr(self, "_resume_cache", None) is None:
             state = self.stream_state
-            saved_cursor = state.get(_CURSOR_STATE_KEY)
-            saved_window_end = state.get(_WINDOW_END_STATE_KEY)
+            saved_cursor = state.get(CURSOR_STATE_KEY)
+            saved_window_end = state.get(WINDOW_END_STATE_KEY)
             if saved_cursor and saved_window_end:
                 self._resume_cache = (saved_cursor, parse(saved_window_end))
             else:
-                state.pop(_CURSOR_STATE_KEY, None)
-                state.pop(_WINDOW_END_STATE_KEY, None)
+                state.pop(CURSOR_STATE_KEY, None)
+                state.pop(WINDOW_END_STATE_KEY, None)
                 self._resume_cache = ("", parse("now"))
         return self._resume_cache
 
@@ -276,15 +276,15 @@ class CBX1Stream(RESTStream):
                 # upper bound and clear the intra-run cursor.
                 state["replication_key"] = replication_key
                 state["replication_key_value"] = window_end_iso
-                state.pop(_CURSOR_STATE_KEY, None)
-                state.pop(_WINDOW_END_STATE_KEY, None)
+                state.pop(CURSOR_STATE_KEY, None)
+                state.pop(WINDOW_END_STATE_KEY, None)
                 self._write_state_message()
                 finished = True
             else:
                 # Persist the resume point (cursor + pinned window) WITHOUT advancing
                 # the run-to-run watermark.
-                state[_CURSOR_STATE_KEY] = next_token
-                state[_WINDOW_END_STATE_KEY] = window_end_iso
+                state[CURSOR_STATE_KEY] = next_token
+                state[WINDOW_END_STATE_KEY] = window_end_iso
                 self._write_state_message()
                 token = next_token
 

--- a/tap_cbx1/constants.py
+++ b/tap_cbx1/constants.py
@@ -3,3 +3,8 @@ CODE_KEY = "Code"
 ACCESS_TOKEN = "AccessToken"
 CRM_KEY = "CRMSystem"
 HOTGLUE_PRINCIPAL_ID_ENV = "HOTGLUE_PRINCIPAL_ID"
+
+# Records per page for keyset pagination. Keyset has no per-page skip cost, so a
+# larger page just cuts round-trips without making any page more expensive.
+PAGE_SIZE_KEY = "page_size"
+DEFAULT_PAGE_SIZE = 500

--- a/tap_cbx1/constants.py
+++ b/tap_cbx1/constants.py
@@ -2,9 +2,9 @@ ORG_ID_KEY = "OrgId"
 CODE_KEY = "Code"
 ACCESS_TOKEN = "AccessToken"
 CRM_KEY = "CRMSystem"
-HOTGLUE_PRINCIPAL_ID_ENV = "HOTGLUE_PRINCIPAL_ID"
+HOTGLUE_PRINCIPAL_ID = "HOTGLUE_PRINCIPAL_ID"
 
 # Records per page for keyset pagination. Keyset has no per-page skip cost, so a
 # larger page just cuts round-trips without making any page more expensive.
 PAGE_SIZE_KEY = "page_size"
-DEFAULT_PAGE_SIZE = 500
+DEFAULT_PAGE_SIZE = 100

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -2,6 +2,7 @@ import logging
 from typing import Iterable
 
 from singer_sdk import typing as th
+from singer_sdk.exceptions import FatalAPIError
 
 from tap_cbx1.client import CBX1Stream
 
@@ -51,10 +52,18 @@ class AccountStream(CBX1Stream):
     def request_records(self, context) -> Iterable[dict]:
         try:
             yield from super().request_records(context)
-        except Exception as e:
+        except FatalAPIError as e:
+            # A missing ACCOUNT egestion mapping makes the list endpoint return a
+            # 4xx, which the SDK surfaces as FatalAPIError. Treat that as "no records
+            # for this tenant" and yield nothing. We deliberately catch ONLY
+            # FatalAPIError (4xx): transient failures (5xx/timeouts -> RetriableAPIError,
+            # connection errors) and the keyset-anomaly RuntimeError are NOT caught and
+            # propagate, so the run fails loudly instead of silently dropping records
+            # and recording false progress.
             logger.warning(
-                "Could not fetch account records for this tenant "
-                "(likely no ACCOUNT egestion mapping configured): %s",
+                "ACCOUNT egestion list returned a client error for this tenant "
+                "(likely no ACCOUNT egestion mapping configured); yielding no "
+                "records: %s",
                 e,
             )
 

--- a/tap_cbx1/streams.py
+++ b/tap_cbx1/streams.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from singer_sdk import typing as th
 from singer_sdk.exceptions import FatalAPIError
 
-from tap_cbx1.client import CBX1Stream
+from tap_cbx1.client import CBX1Stream, CURSOR_STATE_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -50,20 +50,27 @@ class AccountStream(CBX1Stream):
             return _ACCOUNT_FALLBACK_SCHEMA
 
     def request_records(self, context) -> Iterable[dict]:
+        yielded_any = False
         try:
-            yield from super().request_records(context)
+            for record in super().request_records(context):
+                yielded_any = True
+                yield record
         except FatalAPIError as e:
-            # A missing ACCOUNT egestion mapping makes the list endpoint return a
-            # 4xx, which the SDK surfaces as FatalAPIError. Treat that as "no records
-            # for this tenant" and yield nothing. We deliberately catch ONLY
-            # FatalAPIError (4xx): transient failures (5xx/timeouts -> RetriableAPIError,
-            # connection errors) and the keyset-anomaly RuntimeError are NOT caught and
-            # propagate, so the run fails loudly instead of silently dropping records
-            # and recording false progress.
+            # Treat a 4xx as "no ACCOUNT egestion mapping for this tenant" and yield
+            # nothing ONLY when it happens before any progress: the very first fetch
+            # of a fresh window, with no records yielded AND no resume cursor
+            # persisted. A 4xx AFTER progress is a real error — swallowing it would
+            # leave the persisted (cursor, window_end) in state, so every later run
+            # would resume to the same failing page, swallow again, and never advance
+            # or clear: a permanent silent wedge. Fail loudly in that case. Transient
+            # errors (5xx/timeouts -> RetriableAPIError) and the keyset-anomaly
+            # RuntimeError are not caught here and always propagate.
+            if yielded_any or self.stream_state.get(CURSOR_STATE_KEY):
+                raise
             logger.warning(
-                "ACCOUNT egestion list returned a client error for this tenant "
-                "(likely no ACCOUNT egestion mapping configured); yielding no "
-                "records: %s",
+                "ACCOUNT egestion list returned a client error on the first page "
+                "for this tenant (likely no ACCOUNT egestion mapping configured); "
+                "yielding no records: %s",
                 e,
             )
 

--- a/tap_cbx1/tap.py
+++ b/tap_cbx1/tap.py
@@ -6,7 +6,7 @@ from singer_sdk import Tap
 from singer_sdk import typing as th
 
 from tap_cbx1.client import CBX1Stream
-from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY
+from tap_cbx1.constants import ORG_ID_KEY, CODE_KEY, PAGE_SIZE_KEY, DEFAULT_PAGE_SIZE
 from tap_cbx1.streams import AccountStream, ContactStream
 
 STREAM_TYPES = [
@@ -32,7 +32,14 @@ class TapCBX1(Tap):
 
     config_jsonschema = th.PropertiesList(
         th.Property(CODE_KEY, th.StringType, required=True),
-        th.Property(ORG_ID_KEY, th.StringType, required=True)
+        th.Property(ORG_ID_KEY, th.StringType, required=True),
+        th.Property(
+            PAGE_SIZE_KEY,
+            th.IntegerType,
+            required=False,
+            default=DEFAULT_PAGE_SIZE,
+            description="Records per page for keyset pagination (default 500).",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[CBX1Stream]:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -143,10 +143,10 @@ def test_payload_pins_window_end_from_saved_state(monkeypatch):
 
 def test_page_size_default_override_and_invalid():
     CBX1Stream = _cbx1()
-    assert CBX1Stream.page_size.fget(SimpleNamespace(config={})) == 500
+    assert CBX1Stream.page_size.fget(SimpleNamespace(config={})) == 100
     assert CBX1Stream.page_size.fget(SimpleNamespace(config={"page_size": 250})) == 250
     # An invalid value falls back to the default rather than crashing the run.
-    assert CBX1Stream.page_size.fget(SimpleNamespace(config={"page_size": "nope"})) == 500
+    assert CBX1Stream.page_size.fget(SimpleNamespace(config={"page_size": "nope"})) == 100
 
 
 # =====================================================================================

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,8 +1,14 @@
-"""Tests for tap-side filtering of HotGlue-authored records.
+"""Tests for tap-side filtering and keyset (cursor) pagination.
 
 These tests stub the prepared HTTP request and the decorated request
 function so we exercise `request_records` end-to-end without booting
 Singer SDK auth or schema fetches.
+
+Pagination uses keyset/cursor paging: the request body carries a `cursor`
+(empty string on the first page) instead of a `pageNumber`, and the backend
+returns the next `data.cursor`. We never compute a `skip = pageNumber *
+pageSize` offset, which on large orgs forces Mongo to walk every skipped
+index entry per page (CM100 timeout / CPU spike).
 """
 
 import os
@@ -28,8 +34,49 @@ def _stream(*, replication_key=None, start_date=None):
     return obj
 
 
+def _payload(stream, token=""):
+    return stream.prepare_request_payload(None, token)
+
+
 def _filters(stream):
-    return stream.prepare_request_payload(None, 0)["filters"]
+    return _payload(stream)["filters"]
+
+
+# ---- prepare_request_payload: keyset cursor, no pageNumber ----
+
+def test_payload_uses_cursor_not_pagenumber(monkeypatch):
+    """Keyset contract: the body carries a `cursor`, never a `pageNumber`.
+    Pushing a deep skip offset to Mongo (skip = pageNumber * pageSize) walks
+    every skipped index entry per page → CM100 timeout on large orgs."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    payload = _payload(_stream(), token="")
+    assert "pageNumber" not in payload
+    assert "cursor" in payload
+
+
+def test_payload_cursor_empty_string_on_first_page(monkeypatch):
+    """First page: a None token (Singer SDK's initial value) maps to the empty
+    string, which signals keyset mode to the backend."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    assert _payload(_stream(), token=None)["cursor"] == ""
+    # The tap also seeds the first page with the literal empty string.
+    assert _payload(_stream(), token="")["cursor"] == ""
+
+
+def test_payload_echoes_backend_cursor_token(monkeypatch):
+    """Subsequent pages: the opaque backend token is sent back verbatim."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    token = "eyJ1cGRhdGVkQXQiOiIyMDI2LTAxLTAxIiwiaWQiOiJhYmMifQ=="
+    assert _payload(_stream(), token=token)["cursor"] == token
+
+
+def test_payload_keeps_sort_and_page_size(monkeypatch):
+    """sortBy/sortDirection/pageSize are unchanged by the cursor migration."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    payload = _payload(_stream(replication_key="updatedAt"), token="")
+    assert payload["pageSize"] == 10
+    assert payload["sortBy"] == "updatedAt"
+    assert payload["sortDirection"] == "DESC"
 
 
 # ---- prepare_request_payload: server-side filter must be absent ----
@@ -62,45 +109,33 @@ def test_payload_includes_replication_key_when_set(monkeypatch):
 PAGE_SIZE = 10
 
 
-def _mock_response(records, page_number, total_pages, *, last=None, slice_shape=False):
-    """Build a mocked response in the backend's Page/Slice DTO shape.
+def _mock_response(records, *, cursor=None, last=None):
+    """Build a mocked response in the backend's keyset DTO shape.
 
-    `last` defaults to a realistic value derived from the page index
-    (`page_number >= total_pages - 1`) when `total_pages` is known. Pass an
-    explicit `last` to override, or `slice_shape=True` to emulate the
-    count-free backend that returns null `totalElements`/`totalPages`.
+    `cursor` is the opaque next-page token (None/"" ⇒ no further page).
+    `last` is the backend's terminal boolean; defaults to None (absent).
     """
-    if last is None and total_pages is not None:
-        last = page_number >= total_pages - 1
-
-    total_elements = None if slice_shape else (
-        total_pages * PAGE_SIZE if total_pages is not None else None
-    )
-    out_total_pages = None if slice_shape else total_pages
-
     resp = MagicMock()
     resp.json.return_value = {
         "data": {
             "content": records,
-            "number": page_number,
             "size": PAGE_SIZE,
-            "first": page_number == 0,
             "last": last,
+            "cursor": cursor,
             "numberOfElements": len(records),
             "empty": len(records) == 0,
-            "totalElements": total_elements,
-            "totalPages": out_total_pages,
         }
     }
     return resp
 
 
-def _stream_with_pages(pages, *, slice_shape=False):
-    """Build a stream-like object whose `request_records` walks the given
-    list of (records, page_number, total_pages) tuples.
+def _stream_with_pages(pages):
+    """Build a stream-like object whose `request_records` walks the given list
+    of page dicts. Each entry is ``{"records": [...], "cursor": <token-or-None>,
+    "last": <bool-or-None>}``.
 
-    Each emitted page carries a realistic `last` flag, so pagination
-    terminates on the final page itself — no trailing fetch is required.
+    The transport returns each page in order; pagination terminates via the
+    real `get_next_page_token` (last / missing-cursor / short-page).
     """
     os.environ.setdefault("BASE_URL", "http://example.invalid/")
     from tap_cbx1.client import CBX1Stream
@@ -112,16 +147,16 @@ def _stream_with_pages(pages, *, slice_shape=False):
     obj.request_decorator = lambda fn: fn
 
     iterator = iter(pages)
-    last_total_pages = pages[-1][2] if pages else 1
 
     def _next_response(*_args, **_kwargs):
         try:
-            return _mock_response(*next(iterator), slice_shape=slice_shape)
+            page = next(iterator)
         except StopIteration:
-            # Safety net: should not be reached now that the final page sets
-            # `last=True`. Emit a terminal empty page if the loop overruns.
-            return _mock_response([], last_total_pages, last_total_pages,
-                                  last=True, slice_shape=slice_shape)
+            # Safety net: should not be reached. Emit a terminal empty page.
+            return _mock_response([], cursor=None, last=True)
+        return _mock_response(
+            page["records"], cursor=page.get("cursor"), last=page.get("last")
+        )
 
     obj._request = _next_response
     obj.get_next_page_token = lambda resp, prev: (
@@ -138,8 +173,8 @@ def _rec(updated_by, _id="id"):
 def _full_page(updated_by, prefix):
     """A full page (len == PAGE_SIZE) of identically-authored records.
 
-    Non-final pages must be full; under the count-free contract a short page
-    is itself a terminal signal, so intermediate pages carry PAGE_SIZE records.
+    Non-final pages must be full; a short page is itself a terminal signal,
+    so intermediate pages carry PAGE_SIZE records.
     """
     return [_rec(updated_by, f"{prefix}{i}") for i in range(PAGE_SIZE)]
 
@@ -147,7 +182,8 @@ def _full_page(updated_by, prefix):
 def test_request_records_skips_hotglue_authored(monkeypatch):
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        ([_rec(HOTGLUE_UUID, "a"), _rec("other", "b"), _rec(HOTGLUE_UUID, "c")], 0, 1),
+        {"records": [_rec(HOTGLUE_UUID, "a"), _rec("other", "b"), _rec(HOTGLUE_UUID, "c")],
+         "cursor": None, "last": True},
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["b"]
@@ -156,7 +192,7 @@ def test_request_records_skips_hotglue_authored(monkeypatch):
 def test_request_records_passthrough_when_env_unset(monkeypatch):
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
     pages = [
-        ([_rec(HOTGLUE_UUID, "a"), _rec("other", "b")], 0, 1),
+        {"records": [_rec(HOTGLUE_UUID, "a"), _rec("other", "b")], "cursor": None, "last": True},
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["a", "b"]
@@ -164,15 +200,16 @@ def test_request_records_passthrough_when_env_unset(monkeypatch):
 
 def test_pagination_continues_across_all_filtered_page(monkeypatch):
     """Critical: a page where every record is HotGlue must NOT stop pagination.
-    The next page is fetched regardless of how many records survived the filter."""
+    The next page is fetched (via cursor) regardless of how many records
+    survived the tap-side filter."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        # page 0: ALL records are HotGlue — yields nothing (full page, not last)
-        (_full_page(HOTGLUE_UUID, "a"), 0, 3),
-        # page 1: also all HotGlue (full page, not last)
-        (_full_page(HOTGLUE_UUID, "d"), 1, 3),
+        # page 0: ALL records are HotGlue — yields nothing (full page, has cursor)
+        {"records": _full_page(HOTGLUE_UUID, "a"), "cursor": "c1", "last": False},
+        # page 1: also all HotGlue (full page, has cursor)
+        {"records": _full_page(HOTGLUE_UUID, "d"), "cursor": "c2", "last": False},
         # page 2: finally a non-HotGlue record (short/last page)
-        ([_rec(HOTGLUE_UUID, "f"), _rec("other", "survivor")], 2, 3),
+        {"records": [_rec(HOTGLUE_UUID, "f"), _rec("other", "survivor")], "cursor": None, "last": True},
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["survivor"]
@@ -183,18 +220,18 @@ def test_pagination_terminates_when_all_pages_filtered(monkeypatch):
     cleanly (no infinite loop, no exception)."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        (_full_page(HOTGLUE_UUID, "a"), 0, 2),
-        ([_rec(HOTGLUE_UUID, "b")], 1, 2),  # short final page
+        {"records": _full_page(HOTGLUE_UUID, "a"), "cursor": "c1", "last": False},
+        {"records": [_rec(HOTGLUE_UUID, "b")], "cursor": None, "last": True},  # short final page
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert out == []
 
 
 def test_pagination_handles_empty_response_page(monkeypatch):
-    """An empty content array must terminate the loop cleanly (last-page case)."""
+    """A single short page must terminate the loop cleanly (last-page case)."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        ([_rec("other", "a")], 0, 1),
+        {"records": [_rec("other", "a")], "cursor": None, "last": True},
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["a"]
@@ -205,13 +242,14 @@ def test_request_records_handles_missing_updatedby_field(monkeypatch):
     `None != hotglue_uuid` is the correct semantic."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        ([_rec(None, "legacy"), _rec(HOTGLUE_UUID, "skip"), _rec("other", "keep")], 0, 1),
+        {"records": [_rec(None, "legacy"), _rec(HOTGLUE_UUID, "skip"), _rec("other", "keep")],
+         "cursor": None, "last": True},
     ]
     out = list(_stream_with_pages(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["legacy", "keep"]
 
 
-# ---- get_next_page_token: termination contract ----
+# ---- get_next_page_token: keyset termination contract ----
 
 def _token_for(page_data):
     """Call the real CBX1Stream.get_next_page_token against a raw `data` dict."""
@@ -221,114 +259,93 @@ def _token_for(page_data):
     obj.page_size = PAGE_SIZE
     resp = MagicMock()
     resp.json.return_value = {"data": page_data}
-    return CBX1Stream.get_next_page_token(obj, resp, previous_token=page_data.get("number"))
+    return CBX1Stream.get_next_page_token(obj, resp, previous_token=None)
 
 
-def test_next_page_token_terminates_on_last_true_without_totalpages():
-    """Slice scenario: `last: True` with totalPages ABSENT must terminate and
-    must NOT raise TypeError (no arithmetic on a null totalPages)."""
-    # A FULL page so the short-page defensive check does not mask the `last` path.
+def test_next_page_token_returns_cursor_on_full_non_last_page():
+    """Happy path: full page, last=False, cursor present → return the cursor."""
     page = {
-        "content": [_rec(HOTGLUE_UUID, f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 5,
-        "size": PAGE_SIZE,
+        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
+        "last": False,
+        "cursor": "next-token-abc",
+    }
+    assert _token_for(page) == "next-token-abc"
+
+
+def test_next_page_token_terminates_on_last_true():
+    """`last: True` terminates even when a cursor is still present and the page
+    is full (termination comes from `last`, not the short-page check)."""
+    page = {
+        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
         "last": True,
-        # totalElements / totalPages intentionally absent (count-free backend)
+        "cursor": "would-be-next",  # ignored: `last` wins
     }
     assert _token_for(page) is None
 
 
-def test_next_page_token_no_typeerror_when_totalpages_null_and_last_false():
-    """Count-free backend mid-stream: last=False, totalPages=None, full page →
-    must advance (not crash) and must not compare against None."""
+def test_next_page_token_terminates_when_cursor_missing():
+    """No `cursor` key (or a non-keyset / older backend) terminates."""
     page = {
-        "content": [_rec(HOTGLUE_UUID, f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 2,
-        "size": PAGE_SIZE,
+        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
         "last": False,
-        "totalElements": None,
-        "totalPages": None,
+        # cursor intentionally absent
     }
-    assert _token_for(page) == 3  # previous_token(2) + 1
+    assert _token_for(page) is None
 
 
-def test_next_page_token_terminates_on_short_page_when_last_absent():
-    """Backend omits `last` entirely: a short page (len < page_size) is the
-    terminal signal."""
+def test_next_page_token_terminates_when_cursor_empty():
+    """An empty-string cursor means the backend has no more pages."""
+    page = {
+        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
+        "last": False,
+        "cursor": "",
+    }
+    assert _token_for(page) is None
+
+
+def test_next_page_token_terminates_on_short_page():
+    """A short page (len < page_size) is a terminal signal even if a cursor is
+    present."""
     page = {
         "content": [_rec("other", f"x{i}") for i in range(3)],  # 3 < PAGE_SIZE
-        "number": 0,
-        "size": PAGE_SIZE,
-        # no `last`, no totals
-    }
-    assert _token_for(page) is None
-
-
-def test_next_page_token_terminates_on_empty_page_when_last_absent():
-    page = {"content": [], "number": 0, "size": PAGE_SIZE}
-    assert _token_for(page) is None
-
-
-def test_next_page_token_legacy_totalpages_fallback_when_last_absent():
-    """Legacy Page DTO without `last`: stop when number >= totalPages - 1, but
-    only when both are non-null. A full final page must still terminate."""
-    final = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 2,
-        "totalPages": 3,  # number(2) >= 3 - 1 → last page
-    }
-    assert _token_for(final) is None
-
-    mid = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 1,
-        "totalPages": 3,  # number(1) < 3 - 1 → more pages
-    }
-    assert _token_for(mid) == 2
-
-
-def test_next_page_token_advances_on_full_page_current_backend():
-    """Current backend: full page, last=False, totalPages present → advance."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "number": 0,
         "last": False,
-        "totalElements": 30,
-        "totalPages": 3,
+        "cursor": "still-here",
     }
-    assert _token_for(page) == 1
+    assert _token_for(page) is None
 
 
-# ---- CROSS-REPO CONTRACT / E2E: tap <-> backend handshake, both versions ----
+def test_next_page_token_terminates_on_empty_page():
+    page = {"content": [], "last": False, "cursor": "x"}
+    assert _token_for(page) is None
 
-def _page_json(records, number, total_pages, *, slice_shape):
-    """Emit one page in the EXACT backend JSON shape.
 
-    slice_shape=False → legacy Page DTO (totalElements/totalPages populated).
-    slice_shape=True  → count-free Slice DTO (totalElements/totalPages null).
-    Both shapes always carry `last`.
+# ---- CROSS-REPO CONTRACT / E2E: tap <-> backend handshake ----
+
+def _page_json(records, *, cursor, last):
+    """Emit one page in the EXACT backend keyset JSON shape.
+
+    `cursor` is the opaque next-page token the backend returns; the tap echoes
+    it back as the body `cursor` on the following request. `last` is the
+    backend's terminal boolean.
     """
-    last = number >= total_pages - 1
     return {
         "data": {
             "content": records,
-            "number": number,
             "size": PAGE_SIZE,
-            "first": number == 0,
             "last": last,
+            "cursor": cursor,
             "numberOfElements": len(records),
             "empty": len(records) == 0,
-            "totalElements": None if slice_shape else total_pages * PAGE_SIZE,
-            "totalPages": None if slice_shape else total_pages,
         }
     }
 
 
 def _e2e_stream(page_jsons, *, max_iterations=50):
     """Drive the REAL request_records over a mocked transport that returns the
-    given sequence of raw page JSON dicts. The transport itself emits the JSON;
-    we do NOT bypass get_next_page_token. Iteration is capped to fail loudly on
-    a runaway loop instead of hanging.
+    given sequence of raw page JSON dicts AND asserts the tap echoes each
+    backend cursor back on the next request body. We do NOT bypass
+    get_next_page_token or prepare_request_payload. Iteration is capped to fail
+    loudly on a runaway loop instead of hanging.
     """
     os.environ.setdefault("BASE_URL", "http://example.invalid/")
     from tap_cbx1.client import CBX1Stream
@@ -336,17 +353,27 @@ def _e2e_stream(page_jsons, *, max_iterations=50):
     obj = SimpleNamespace()
     obj.logger = MagicMock()
     obj.page_size = PAGE_SIZE
-    obj.prepare_request = lambda context, next_page_token: f"req-{next_page_token}"
-    obj.request_decorator = lambda fn: fn
+    obj.replication_key_field = "updatedAt"
+    obj.get_starting_time = lambda ctx: None
 
-    state = {"calls": 0}
+    state = {"calls": 0, "sent_cursors": []}
+
+    # Build the real request body each call and record the cursor the tap sent,
+    # so the E2E test asserts the full handshake (backend cursor → next body).
+    def _prepare_request(context, next_page_token):
+        body = CBX1Stream.prepare_request_payload(obj, context, next_page_token)
+        state["sent_cursors"].append(body["cursor"])
+        assert "pageNumber" not in body
+        return f"req-{next_page_token}"
+
+    obj.prepare_request = _prepare_request
+    obj.request_decorator = lambda fn: fn
 
     def _transport(*_args, **_kwargs):
         idx = state["calls"]
         state["calls"] += 1
         if state["calls"] > max_iterations:
             raise AssertionError("pagination did not terminate (runaway loop)")
-        # Real transport returns a response object exposing .json()
         payload = page_jsons[idx] if idx < len(page_jsons) else page_jsons[-1]
         resp = MagicMock()
         resp.json.return_value = payload
@@ -360,24 +387,26 @@ def _e2e_stream(page_jsons, *, max_iterations=50):
     return obj, state
 
 
-def _three_page_sequence(slice_shape):
-    """3 pages, 10 + 10 + 4 = 24 records; final page short. Both shapes set
-    `last` on page 2."""
-    total_pages = 3
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], 0, total_pages, slice_shape=slice_shape)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], 1, total_pages, slice_shape=slice_shape)
-    p2 = _page_json([_rec("other", f"p2-{i}") for i in range(4)], 2, total_pages, slice_shape=slice_shape)
+def _three_page_sequence():
+    """3 pages, 10 + 10 + 4 = 24 records; final page short with `last: True`.
+
+    Each non-final page hands the tap an opaque cursor; the final page returns
+    no cursor.
+    """
+    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], cursor="cur-1", last=False)
+    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], cursor="cur-2", last=False)
+    p2 = _page_json([_rec("other", f"p2-{i}") for i in range(4)], cursor=None, last=True)
     return [p0, p1, p2]
 
 
-def test_e2e_contract_legacy_page_shape(monkeypatch):
-    """(a) Legacy Page shape: totals populated. Loop yields ALL 24 records,
-    terminates, no exception."""
+def test_e2e_contract_keyset_handshake(monkeypatch):
+    """Full handshake: the tap seeds an empty cursor, echoes each backend
+    cursor back on the next request, yields ALL 24 records, and terminates."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = _three_page_sequence(slice_shape=False)
-    # Sanity: this fixture really is the legacy shape.
-    assert pages[0]["data"]["totalPages"] == 3
-    assert pages[0]["data"]["totalElements"] == 30
+    pages = _three_page_sequence()
+    # Sanity: this fixture is the keyset shape (cursor present, no totals).
+    assert pages[0]["data"]["cursor"] == "cur-1"
+    assert "totalPages" not in pages[0]["data"]
 
     stream, state = _e2e_stream(pages)
     out = list(stream.request_records(context=None))
@@ -388,40 +417,42 @@ def test_e2e_contract_legacy_page_shape(monkeypatch):
     )
     assert len(out) == 24
     assert state["calls"] == 3  # exactly 3 fetches, no trailing probe
+    # The handshake: first request seeds "", then each backend cursor is echoed.
+    assert state["sent_cursors"] == ["", "cur-1", "cur-2"]
 
 
-def test_e2e_contract_count_free_slice_shape(monkeypatch):
-    """(b) New count-free Slice shape: totalElements/totalPages NULL, `last`
-    drives termination. Same 24 records, terminates, no exception/TypeError."""
+def test_e2e_contract_missing_cursor_terminates(monkeypatch):
+    """A non-keyset / older backend that returns no `cursor` (and no `last`)
+    must terminate after the first page rather than loop forever."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = _three_page_sequence(slice_shape=True)
-    # Sanity: this fixture really is the count-free shape.
-    assert pages[0]["data"]["totalPages"] is None
-    assert pages[0]["data"]["totalElements"] is None
-    assert pages[2]["data"]["last"] is True
-
-    stream, state = _e2e_stream(pages)
+    # Full page, last absent, cursor absent → terminate (no next token).
+    p0 = {
+        "data": {
+            "content": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)],
+            "size": PAGE_SIZE,
+            # no `last`, no `cursor`
+        }
+    }
+    stream, state = _e2e_stream([p0])
     out = list(stream.request_records(context=None))
-    assert len(out) == 24
-    assert [r["id"] for r in out][0] == "p0-0"
-    assert [r["id"] for r in out][-1] == "p2-3"
-    assert state["calls"] == 3
+    assert len(out) == PAGE_SIZE
+    assert state["calls"] == 1  # terminates immediately, no runaway
+    assert state["sent_cursors"] == [""]
 
 
-def test_e2e_contract_slice_full_final_page_with_last_true(monkeypatch):
-    """Count-free edge: the final page is FULL (len == page_size) but carries
-    `last: True`. Termination must come from `last`, not the short-page check."""
+def test_e2e_contract_full_final_page_with_last_true(monkeypatch):
+    """Edge: the final page is FULL (len == page_size) but carries `last: True`.
+    Termination must come from `last`, not the short-page check."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    total_pages = 2
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], 0, total_pages, slice_shape=True)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], 1, total_pages, slice_shape=True)
+    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], cursor="cur-1", last=False)
+    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], cursor="cur-2", last=True)
     assert p1["data"]["last"] is True and len(p1["data"]["content"]) == PAGE_SIZE
-    assert p1["data"]["totalPages"] is None  # would TypeError under old logic
 
     stream, state = _e2e_stream([p0, p1])
     out = list(stream.request_records(context=None))
     assert len(out) == 2 * PAGE_SIZE
     assert state["calls"] == 2  # full final page still stops via `last`
+    assert state["sent_cursors"] == ["", "cur-1"]
 
 
 # ---- bookmark signpost ----

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,36 +1,67 @@
-"""Tests for tap-side filtering and keyset (cursor) pagination.
+"""Tests for tap-side filtering and durable keyset (cursor) pagination.
 
-These tests stub the prepared HTTP request and the decorated request
-function so we exercise `request_records` end-to-end without booting
-Singer SDK auth or schema fetches.
+These tests stub the prepared HTTP request and the decorated request function so we
+exercise ``request_records`` end-to-end without booting Singer SDK auth or schema
+fetches.
 
-Pagination uses keyset/cursor paging: the request body carries a `cursor`
-(empty string on the first page) instead of a `pageNumber`, and the backend
-returns the next `data.cursor`. We never compute a `skip = pageNumber *
-pageSize` offset, which on large orgs forces Mongo to walk every skipped
-index entry per page (CM100 timeout / CPU spike).
+Pagination uses keyset/cursor paging: the request body carries a ``cursor`` (empty
+string on the first page) instead of a ``pageNumber``, and the backend returns the
+next ``data.cursor``. We never compute ``skip = pageNumber * pageSize``, which on
+large orgs forces Mongo to walk every skipped index entry per page (CM100 timeout /
+CPU spike).
+
+Forward progress is durable: after each page's records are emitted, the next-page
+cursor and the PINNED window upper bound are persisted to Singer state, so a run that
+ends partway resumes from exactly the unread remainder. The run-to-run ``updatedAt``
+bookmark advances only on confirmed window completion.
 """
 
+import copy
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+from pendulum import parse
+
 
 HOTGLUE_UUID = "d6435b86-31f9-470a-97e5-33ed6a5024d5"
+PAGE_SIZE = 10
 
 
-def _stream(*, replication_key=None, start_date=None):
-    """Minimal stream-like object for prepare_request_payload tests."""
+def _cbx1():
     os.environ.setdefault("BASE_URL", "http://example.invalid/")
     from tap_cbx1.client import CBX1Stream
 
+    return CBX1Stream
+
+
+def _rec(updated_by, _id="id", updated_at="2026-01-01T00:00:00.000Z"):
+    return {"id": _id, "updatedBy": updated_by, "updatedAt": updated_at}
+
+
+def _full_page(updated_by, prefix):
+    """A full page (len == PAGE_SIZE) of identically-authored records.
+
+    Non-final pages must be full; a short page is itself a terminal signal.
+    """
+    return [_rec(updated_by, f"{prefix}{i}") for i in range(PAGE_SIZE)]
+
+
+# =====================================================================================
+# prepare_request_payload: keyset cursor, pinned window, no pageNumber
+# =====================================================================================
+
+def _payload_stream(*, replication_key=None, start_date=None, stream_state=None, page_size=PAGE_SIZE):
+    """Minimal stream-like object for prepare_request_payload tests."""
+    CBX1Stream = _cbx1()
     obj = SimpleNamespace()
-    obj.page_size = 10
+    obj.page_size = page_size
     obj.replication_key_field = replication_key
+    obj.stream_state = {} if stream_state is None else stream_state
     obj.get_starting_time = lambda ctx: start_date
-    obj.prepare_request_payload = lambda ctx, tok: CBX1Stream.prepare_request_payload(
-        obj, ctx, tok
-    )
+    obj._resume_state = lambda: CBX1Stream._resume_state(obj)
+    obj.prepare_request_payload = lambda ctx, tok: CBX1Stream.prepare_request_payload(obj, ctx, tok)
     return obj
 
 
@@ -42,142 +73,148 @@ def _filters(stream):
     return _payload(stream)["filters"]
 
 
-# ---- prepare_request_payload: keyset cursor, no pageNumber ----
-
 def test_payload_uses_cursor_not_pagenumber(monkeypatch):
-    """Keyset contract: the body carries a `cursor`, never a `pageNumber`.
-    Pushing a deep skip offset to Mongo (skip = pageNumber * pageSize) walks
-    every skipped index entry per page → CM100 timeout on large orgs."""
+    """Keyset contract: the body carries a `cursor`, never a `pageNumber`."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    payload = _payload(_stream(), token="")
+    payload = _payload(_payload_stream(), token="")
     assert "pageNumber" not in payload
     assert "cursor" in payload
 
 
 def test_payload_cursor_empty_string_on_first_page(monkeypatch):
-    """First page: a None token (Singer SDK's initial value) maps to the empty
-    string, which signals keyset mode to the backend."""
+    """First page: a None token (the seed) maps to the empty string, which signals
+    keyset mode to the backend."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    assert _payload(_stream(), token=None)["cursor"] == ""
-    # The tap also seeds the first page with the literal empty string.
-    assert _payload(_stream(), token="")["cursor"] == ""
+    assert _payload(_payload_stream(), token=None)["cursor"] == ""
+    assert _payload(_payload_stream(), token="")["cursor"] == ""
 
 
 def test_payload_echoes_backend_cursor_token(monkeypatch):
     """Subsequent pages: the opaque backend token is sent back verbatim."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
     token = "eyJ1cGRhdGVkQXQiOiIyMDI2LTAxLTAxIiwiaWQiOiJhYmMifQ=="
-    assert _payload(_stream(), token=token)["cursor"] == token
+    assert _payload(_payload_stream(), token=token)["cursor"] == token
 
 
 def test_payload_keeps_sort_and_page_size(monkeypatch):
-    """sortBy/sortDirection/pageSize are unchanged by the cursor migration."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    payload = _payload(_stream(replication_key="updatedAt"), token="")
-    assert payload["pageSize"] == 10
+    payload = _payload(_payload_stream(replication_key="updatedAt"), token="")
+    assert payload["pageSize"] == PAGE_SIZE
     assert payload["sortBy"] == "updatedAt"
     assert payload["sortDirection"] == "DESC"
 
 
-# ---- prepare_request_payload: server-side filter must be absent ----
-
 def test_payload_does_not_push_updatedby_filter_server_side(monkeypatch):
-    """Even with the env var set, the request payload must NOT carry an
-    updatedBy filter — pushing $ne updatedBy to Mongo regresses tenants
-    where HotGlue is the dominant writer (verified via prod explain)."""
+    """Pushing $ne updatedBy to Mongo regresses tenants where HotGlue dominates."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    assert "updatedBy" not in _filters(_stream())
+    assert "updatedBy" not in _filters(_payload_stream())
 
 
 def test_test_metadata_filter_always_present(monkeypatch):
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    assert _filters(_stream())["testMetadata"] == {"type": "EQUALS", "value": None}
+    assert _filters(_payload_stream())["testMetadata"] == {"type": "EQUALS", "value": None}
 
 
 def test_payload_includes_replication_key_when_set(monkeypatch):
-    from pendulum import parse
-
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    stream = _stream(replication_key="updatedAt", start_date=parse("2026-01-01T00:00:00Z"))
+    stream = _payload_stream(replication_key="updatedAt", start_date=parse("2026-01-01T00:00:00Z"))
     filters = _filters(stream)
     assert filters["updatedAt"]["type"] == "BETWEEN"
     assert "updatedBy" not in filters
 
 
-# ---- request_records: tap-side filter ----
+def test_payload_pins_window_end_from_saved_state(monkeypatch):
+    """On a resume run the BETWEEN endValue is the PINNED window_end from state, not
+    a fresh now() — otherwise a DESC scan would skip records that arrived between
+    runs."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    saved_window_end = "2026-06-10T12:00:00.000000Z"
+    stream = _payload_stream(
+        replication_key="updatedAt",
+        start_date=parse("2026-06-01T00:00:00Z"),
+        stream_state={"cursor": "c2", "window_end": saved_window_end},
+    )
+    assert _filters(stream)["updatedAt"]["endValue"] == saved_window_end
 
-PAGE_SIZE = 10
+
+# =====================================================================================
+# page_size config knob
+# =====================================================================================
+
+def test_page_size_default_override_and_invalid():
+    CBX1Stream = _cbx1()
+    assert CBX1Stream.page_size.fget(SimpleNamespace(config={})) == 500
+    assert CBX1Stream.page_size.fget(SimpleNamespace(config={"page_size": 250})) == 250
+    # An invalid value falls back to the default rather than crashing the run.
+    assert CBX1Stream.page_size.fget(SimpleNamespace(config={"page_size": "nope"})) == 500
 
 
-def _mock_response(records, *, cursor=None, last=None):
-    """Build a mocked response in the backend's keyset DTO shape.
+# =====================================================================================
+# request_records driver harness
+# =====================================================================================
 
-    `cursor` is the opaque next-page token (None/"" ⇒ no further page).
-    `last` is the backend's terminal boolean; defaults to None (absent).
+def _run_stream(pages=None, *, transport=None, stream_state=None, replication_key="updatedAt",
+                start_date=None, page_size=PAGE_SIZE, max_iterations=50):
+    """Drive the REAL request_records over a mocked transport.
+
+    Provides a live ``stream_state`` dict, captures every STATE emission as a deep
+    snapshot in ``obj.states``, records each sent body cursor in ``obj.sent_cursors``,
+    and keeps the last request body in ``obj.last_body``. Pages are dicts:
+    ``{"records": [...], "cursor": <token-or-None>, "last": <bool-or-None>}``.
     """
-    resp = MagicMock()
-    resp.json.return_value = {
-        "data": {
-            "content": records,
-            "size": PAGE_SIZE,
-            "last": last,
-            "cursor": cursor,
-            "numberOfElements": len(records),
-            "empty": len(records) == 0,
-        }
-    }
-    return resp
-
-
-def _stream_with_pages(pages):
-    """Build a stream-like object whose `request_records` walks the given list
-    of page dicts. Each entry is ``{"records": [...], "cursor": <token-or-None>,
-    "last": <bool-or-None>}``.
-
-    The transport returns each page in order; pagination terminates via the
-    real `get_next_page_token` (last / missing-cursor / short-page).
-    """
-    os.environ.setdefault("BASE_URL", "http://example.invalid/")
-    from tap_cbx1.client import CBX1Stream
-
+    CBX1Stream = _cbx1()
     obj = SimpleNamespace()
     obj.logger = MagicMock()
-    obj.page_size = PAGE_SIZE
-    obj.prepare_request = lambda context, next_page_token: f"req-{next_page_token}"
+    obj.page_size = page_size
+    obj.replication_key = replication_key
+    obj.replication_key_field = "updatedAt"
+    obj.stream_state = {} if stream_state is None else stream_state
+    obj.get_starting_time = lambda ctx: start_date
+    obj.states = []
+    obj.sent_cursors = []
+    obj.last_body = None
+
+    def _prepare(context, next_page_token):
+        body = CBX1Stream.prepare_request_payload(obj, context, next_page_token)
+        obj.sent_cursors.append(body["cursor"])
+        obj.last_body = body
+        return f"req-{next_page_token}"
+
+    obj.prepare_request = _prepare
     obj.request_decorator = lambda fn: fn
+    obj._write_state_message = lambda: obj.states.append(copy.deepcopy(obj.stream_state))
 
-    iterator = iter(pages)
+    if transport is not None:
+        obj._request = transport
+    else:
+        calls = {"n": 0}
 
-    def _next_response(*_args, **_kwargs):
-        try:
-            page = next(iterator)
-        except StopIteration:
-            # Safety net: should not be reached. Emit a terminal empty page.
-            return _mock_response([], cursor=None, last=True)
-        return _mock_response(
-            page["records"], cursor=page.get("cursor"), last=page.get("last")
-        )
+        def _t(*_a, **_k):
+            i = calls["n"]
+            calls["n"] += 1
+            if calls["n"] > max_iterations:
+                raise AssertionError("pagination did not terminate (runaway loop)")
+            page = pages[i] if i < len(pages) else pages[-1]
+            resp = MagicMock()
+            resp.json.return_value = {
+                "data": {
+                    "content": page["records"],
+                    "cursor": page.get("cursor"),
+                    "last": page.get("last"),
+                    "size": page_size,
+                }
+            }
+            return resp
 
-    obj._request = _next_response
-    obj.get_next_page_token = lambda resp, prev: (
-        CBX1Stream.get_next_page_token(obj, resp, prev)
-    )
+        obj._request = _t
+
+    obj.get_next_page_token = lambda resp, prev: CBX1Stream.get_next_page_token(obj, resp, prev)
+    obj._resume_state = lambda: CBX1Stream._resume_state(obj)
     obj.request_records = lambda context: CBX1Stream.request_records(obj, context)
     return obj
 
 
-def _rec(updated_by, _id="id"):
-    return {"id": _id, "updatedBy": updated_by, "updatedAt": "2026-01-01T00:00:00.000Z"}
-
-
-def _full_page(updated_by, prefix):
-    """A full page (len == PAGE_SIZE) of identically-authored records.
-
-    Non-final pages must be full; a short page is itself a terminal signal,
-    so intermediate pages carry PAGE_SIZE records.
-    """
-    return [_rec(updated_by, f"{prefix}{i}") for i in range(PAGE_SIZE)]
-
+# ---- tap-side HotGlue filter ----
 
 def test_request_records_skips_hotglue_authored(monkeypatch):
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
@@ -185,7 +222,7 @@ def test_request_records_skips_hotglue_authored(monkeypatch):
         {"records": [_rec(HOTGLUE_UUID, "a"), _rec("other", "b"), _rec(HOTGLUE_UUID, "c")],
          "cursor": None, "last": True},
     ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
+    out = list(_run_stream(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["b"]
 
 
@@ -194,67 +231,163 @@ def test_request_records_passthrough_when_env_unset(monkeypatch):
     pages = [
         {"records": [_rec(HOTGLUE_UUID, "a"), _rec("other", "b")], "cursor": None, "last": True},
     ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
+    out = list(_run_stream(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["a", "b"]
 
 
 def test_pagination_continues_across_all_filtered_page(monkeypatch):
-    """Critical: a page where every record is HotGlue must NOT stop pagination.
-    The next page is fetched (via cursor) regardless of how many records
-    survived the tap-side filter."""
+    """A page where every record is HotGlue must NOT stop pagination — the cursor
+    drives the next fetch regardless of how many records survived the filter."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
-        # page 0: ALL records are HotGlue — yields nothing (full page, has cursor)
         {"records": _full_page(HOTGLUE_UUID, "a"), "cursor": "c1", "last": False},
-        # page 1: also all HotGlue (full page, has cursor)
         {"records": _full_page(HOTGLUE_UUID, "d"), "cursor": "c2", "last": False},
-        # page 2: finally a non-HotGlue record (short/last page)
         {"records": [_rec(HOTGLUE_UUID, "f"), _rec("other", "survivor")], "cursor": None, "last": True},
     ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
+    out = list(_run_stream(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["survivor"]
 
 
-def test_pagination_terminates_when_all_pages_filtered(monkeypatch):
-    """Worst case: every page is all-HotGlue. Must yield nothing and terminate
-    cleanly (no infinite loop, no exception)."""
-    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        {"records": _full_page(HOTGLUE_UUID, "a"), "cursor": "c1", "last": False},
-        {"records": [_rec(HOTGLUE_UUID, "b")], "cursor": None, "last": True},  # short final page
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
-    assert out == []
-
-
 def test_pagination_handles_empty_response_page(monkeypatch):
-    """A single short page must terminate the loop cleanly (last-page case)."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
-    pages = [
-        {"records": [_rec("other", "a")], "cursor": None, "last": True},
-    ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
+    pages = [{"records": [_rec("other", "a")], "cursor": None, "last": True}]
+    out = list(_run_stream(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["a"]
 
 
 def test_request_records_handles_missing_updatedby_field(monkeypatch):
-    """Records with no updatedBy stamp (e.g., legacy data) must pass through —
-    `None != hotglue_uuid` is the correct semantic."""
     monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
     pages = [
         {"records": [_rec(None, "legacy"), _rec(HOTGLUE_UUID, "skip"), _rec("other", "keep")],
          "cursor": None, "last": True},
     ]
-    out = list(_stream_with_pages(pages).request_records(context=None))
+    out = list(_run_stream(pages).request_records(context=None))
     assert [r["id"] for r in out] == ["legacy", "keep"]
 
 
-# ---- get_next_page_token: keyset termination contract ----
+def test_request_records_handles_missing_data_key(monkeypatch):
+    """Defensive parse: a response with no `data` key must not raise (Mycroft #3)."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+
+    def transport(*_a, **_k):
+        resp = MagicMock()
+        resp.json.return_value = {}  # no 'data'
+        return resp
+
+    out = list(_run_stream(transport=transport).request_records(context=None))
+    assert out == []
+
+
+# =====================================================================================
+# durable forward progress: mid-run failure, resume, completion
+# =====================================================================================
+
+def test_mid_run_failure_persists_resume_cursor(monkeypatch):
+    """Acceptance: transport raises while fetching page k -> pages < k are emitted, a
+    STATE carrying the page-k cursor + pinned window is persisted, and the run-to-run
+    watermark is NOT advanced (no false progress)."""
+    from singer_sdk.exceptions import RetriableAPIError
+
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    calls = {"n": 0}
+    p0 = {"records": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], "cursor": "c1", "last": False}
+    p1 = {"records": [_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], "cursor": "c2", "last": False}
+
+    def transport(*_a, **_k):
+        i = calls["n"]
+        calls["n"] += 1
+        if i == 0:
+            page = p0
+        elif i == 1:
+            page = p1
+        else:
+            raise RetriableAPIError("transport boom fetching page 2")
+        resp = MagicMock()
+        resp.json.return_value = {"data": {"content": page["records"], "cursor": page["cursor"],
+                                           "last": page["last"], "size": PAGE_SIZE}}
+        return resp
+
+    obj = _run_stream(transport=transport, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
+    out = []
+    with pytest.raises(RetriableAPIError):
+        for r in obj.request_records(context=None):
+            out.append(r)
+
+    assert [r["id"] for r in out] == (
+        [f"p0-{i}" for i in range(PAGE_SIZE)] + [f"p1-{i}" for i in range(PAGE_SIZE)]
+    )
+    # Resume point persisted: cursor for the unread page 2 + a pinned window_end.
+    assert obj.stream_state["cursor"] == "c2"
+    assert "window_end" in obj.stream_state
+    # The run-to-run bookmark must NOT have advanced (partial run).
+    assert "replication_key_value" not in obj.stream_state
+
+
+def test_resume_reads_only_remainder_against_pinned_window(monkeypatch):
+    """Acceptance: a resume run seeds the saved cursor, reuses the PINNED window
+    (not a fresh now()), emits only the remainder, and on completion advances the
+    watermark to the pinned window and clears the cursor."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    saved_window_end = "2026-06-10T12:00:00.000000Z"
+    state = {
+        "cursor": "c2",
+        "window_end": saved_window_end,
+        "replication_key": "updatedAt",
+        "replication_key_value": "2026-06-01T00:00:00.000000Z",
+    }
+    pages = [{"records": [_rec("other", f"p2-{i}") for i in range(3)], "cursor": None, "last": True}]
+    obj = _run_stream(pages, stream_state=state, start_date=parse("2026-06-01T00:00:00Z"))
+
+    out = list(obj.request_records(context=None))
+    assert [r["id"] for r in out] == [f"p2-{i}" for i in range(3)]
+    # Resumed from the saved cursor, not "".
+    assert obj.sent_cursors[0] == "c2"
+    # Used the pinned window_end as the upper bound (no skip of between-run arrivals).
+    assert obj.last_body["filters"]["updatedAt"]["endValue"] == saved_window_end
+    # Completion advanced the watermark to the pinned window_end and cleared resume state.
+    assert obj.stream_state["replication_key_value"] == saved_window_end
+    assert obj.stream_state["replication_key"] == "updatedAt"
+    assert "cursor" not in obj.stream_state
+    assert "window_end" not in obj.stream_state
+
+
+def test_completion_advances_watermark_to_pinned_window(monkeypatch):
+    """Acceptance: on full window completion the watermark advances to the pinned
+    window upper bound (== the endValue actually sent) and the cursor is cleared."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    pages = [
+        {"records": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], "cursor": "c1", "last": False},
+        {"records": [_rec("other", "last")], "cursor": None, "last": True},
+    ]
+    obj = _run_stream(pages, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
+
+    out = list(obj.request_records(context=None))
+    assert len(out) == PAGE_SIZE + 1
+    assert obj.stream_state.get("cursor") is None
+    assert obj.stream_state.get("window_end") is None
+    assert obj.stream_state["replication_key"] == "updatedAt"
+    # The committed watermark equals the pinned upper bound used for the BETWEEN filter.
+    assert obj.stream_state["replication_key_value"] == obj.last_body["filters"]["updatedAt"]["endValue"]
+
+
+def test_zero_record_window_still_advances_watermark(monkeypatch):
+    """A window that yields no records (empty first page, last=true) still advances
+    the bookmark — completion, not record count, drives advancement."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    pages = [{"records": [], "cursor": None, "last": True}]
+    obj = _run_stream(pages, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
+
+    out = list(obj.request_records(context=None))
+    assert out == []
+    assert obj.stream_state["replication_key_value"] == obj.last_body["filters"]["updatedAt"]["endValue"]
+
+
+# =====================================================================================
+# get_next_page_token: completion vs loud-failure contract (Mycroft #1)
+# =====================================================================================
 
 def _token_for(page_data):
-    """Call the real CBX1Stream.get_next_page_token against a raw `data` dict."""
-    from tap_cbx1.client import CBX1Stream
-
+    CBX1Stream = _cbx1()
     obj = SimpleNamespace()
     obj.page_size = PAGE_SIZE
     resp = MagicMock()
@@ -263,211 +396,162 @@ def _token_for(page_data):
 
 
 def test_next_page_token_returns_cursor_on_full_non_last_page():
-    """Happy path: full page, last=False, cursor present → return the cursor."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "last": False,
-        "cursor": "next-token-abc",
-    }
-    assert _token_for(page) == "next-token-abc"
+    page = {"content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)], "last": False, "cursor": "next-abc"}
+    assert _token_for(page) == "next-abc"
 
 
 def test_next_page_token_terminates_on_last_true():
-    """`last: True` terminates even when a cursor is still present and the page
-    is full (termination comes from `last`, not the short-page check)."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "last": True,
-        "cursor": "would-be-next",  # ignored: `last` wins
-    }
+    page = {"content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)], "last": True, "cursor": "ignored"}
     assert _token_for(page) is None
 
 
-def test_next_page_token_terminates_when_cursor_missing():
-    """No `cursor` key (or a non-keyset / older backend) terminates."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "last": False,
-        # cursor intentionally absent
-    }
+def test_next_page_token_terminates_on_short_page_without_cursor():
+    page = {"content": [_rec("other", "a")], "last": False}  # short, no cursor -> clean end
     assert _token_for(page) is None
 
 
-def test_next_page_token_terminates_when_cursor_empty():
-    """An empty-string cursor means the backend has no more pages."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)],
-        "last": False,
-        "cursor": "",
-    }
-    assert _token_for(page) is None
-
-
-def test_next_page_token_terminates_on_short_page():
-    """A short page (len < page_size) is a terminal signal even if a cursor is
-    present."""
-    page = {
-        "content": [_rec("other", f"x{i}") for i in range(3)],  # 3 < PAGE_SIZE
-        "last": False,
-        "cursor": "still-here",
-    }
+def test_next_page_token_terminates_on_short_page_with_cursor():
+    page = {"content": [_rec("other", "a")], "last": False, "cursor": "still-here"}
     assert _token_for(page) is None
 
 
 def test_next_page_token_terminates_on_empty_page():
-    page = {"content": [], "last": False, "cursor": "x"}
-    assert _token_for(page) is None
+    assert _token_for({"content": [], "last": False}) is None
 
 
-# ---- CROSS-REPO CONTRACT / E2E: tap <-> backend handshake ----
-
-def _page_json(records, *, cursor, last):
-    """Emit one page in the EXACT backend keyset JSON shape.
-
-    `cursor` is the opaque next-page token the backend returns; the tap echoes
-    it back as the body `cursor` on the following request. `last` is the
-    backend's terminal boolean.
-    """
-    return {
-        "data": {
-            "content": records,
-            "size": PAGE_SIZE,
-            "last": last,
-            "cursor": cursor,
-            "numberOfElements": len(records),
-            "empty": len(records) == 0,
-        }
-    }
+def test_next_page_token_raises_on_full_page_without_cursor():
+    """The data-loss guard (Mycroft #1): a FULL page that is not flagged `last` and
+    carries no cursor cannot be advanced safely. Rather than terminate silently
+    (which would let the bookmark jump to ~now and drop the unread tail — the
+    signature of an older/non-keyset backend), fail loudly."""
+    page = {"content": [_rec("other", f"x{i}") for i in range(PAGE_SIZE)], "last": False}  # no cursor
+    with pytest.raises(RuntimeError):
+        _token_for(page)
 
 
-def _e2e_stream(page_jsons, *, max_iterations=50):
-    """Drive the REAL request_records over a mocked transport that returns the
-    given sequence of raw page JSON dicts AND asserts the tap echoes each
-    backend cursor back on the next request body. We do NOT bypass
-    get_next_page_token or prepare_request_payload. Iteration is capped to fail
-    loudly on a runaway loop instead of hanging.
-    """
-    os.environ.setdefault("BASE_URL", "http://example.invalid/")
-    from tap_cbx1.client import CBX1Stream
+def test_request_records_raises_on_incompatible_backend_without_advancing(monkeypatch):
+    """End-to-end of the guard: a full page + no cursor + not last makes the run fail
+    loudly, emits NO records for that page, and does NOT advance the watermark."""
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    pages = [{"records": _full_page("other", "p0"), "cursor": None, "last": None}]
+    obj = _run_stream(pages, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
 
+    out = []
+    with pytest.raises(RuntimeError):
+        for r in obj.request_records(context=None):
+            out.append(r)
+    assert out == []  # anomaly detected before emitting
+    assert "replication_key_value" not in obj.stream_state
+
+
+# =====================================================================================
+# signpost: now manual (no SDK signpost)
+# =====================================================================================
+
+def test_replication_key_signpost_is_none():
+    """Watermark advancement is manual now (see _increment_stream_state). The SDK
+    signpost is therefore intentionally None."""
+    CBX1Stream = _cbx1()
+    assert CBX1Stream.get_replication_key_signpost(SimpleNamespace(), context=None) is None
+
+
+def test_increment_stream_state_is_noop():
+    """The SDK's ascending high-watermark is disabled; advancement is manual."""
+    CBX1Stream = _cbx1()
     obj = SimpleNamespace()
-    obj.logger = MagicMock()
-    obj.page_size = PAGE_SIZE
-    obj.replication_key_field = "updatedAt"
-    obj.get_starting_time = lambda ctx: None
-
-    state = {"calls": 0, "sent_cursors": []}
-
-    # Build the real request body each call and record the cursor the tap sent,
-    # so the E2E test asserts the full handshake (backend cursor → next body).
-    def _prepare_request(context, next_page_token):
-        body = CBX1Stream.prepare_request_payload(obj, context, next_page_token)
-        state["sent_cursors"].append(body["cursor"])
-        assert "pageNumber" not in body
-        return f"req-{next_page_token}"
-
-    obj.prepare_request = _prepare_request
-    obj.request_decorator = lambda fn: fn
-
-    def _transport(*_args, **_kwargs):
-        idx = state["calls"]
-        state["calls"] += 1
-        if state["calls"] > max_iterations:
-            raise AssertionError("pagination did not terminate (runaway loop)")
-        payload = page_jsons[idx] if idx < len(page_jsons) else page_jsons[-1]
-        resp = MagicMock()
-        resp.json.return_value = payload
-        return resp
-
-    obj._request = _transport
-    obj.get_next_page_token = lambda resp, prev: CBX1Stream.get_next_page_token(
-        obj, resp, prev
-    )
-    obj.request_records = lambda context: CBX1Stream.request_records(obj, context)
-    return obj, state
+    # Must not raise and must not touch any state.
+    assert CBX1Stream._increment_stream_state(obj, {"updatedAt": "2026-01-01T00:00:00Z"}) is None
 
 
-def _three_page_sequence():
-    """3 pages, 10 + 10 + 4 = 24 records; final page short with `last: True`.
-
-    Each non-final page hands the tap an opaque cursor; the final page returns
-    no cursor.
-    """
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], cursor="cur-1", last=False)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], cursor="cur-2", last=False)
-    p2 = _page_json([_rec("other", f"p2-{i}") for i in range(4)], cursor=None, last=True)
-    return [p0, p1, p2]
-
+# =====================================================================================
+# CROSS-REPO CONTRACT / E2E handshake
+# =====================================================================================
 
 def test_e2e_contract_keyset_handshake(monkeypatch):
-    """Full handshake: the tap seeds an empty cursor, echoes each backend
-    cursor back on the next request, yields ALL 24 records, and terminates."""
+    """Full handshake: seed an empty cursor, echo each backend cursor back on the
+    next request, yield ALL 24 records, terminate in exactly 3 fetches, and persist
+    a cursor at each page boundary."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    pages = _three_page_sequence()
-    # Sanity: this fixture is the keyset shape (cursor present, no totals).
-    assert pages[0]["data"]["cursor"] == "cur-1"
-    assert "totalPages" not in pages[0]["data"]
+    pages = [
+        {"records": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], "cursor": "cur-1", "last": False},
+        {"records": [_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], "cursor": "cur-2", "last": False},
+        {"records": [_rec("other", f"p2-{i}") for i in range(4)], "cursor": None, "last": True},
+    ]
+    obj = _run_stream(pages, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
+    out = list(obj.request_records(context=None))
 
-    stream, state = _e2e_stream(pages)
-    out = list(stream.request_records(context=None))
     assert [r["id"] for r in out] == (
         [f"p0-{i}" for i in range(PAGE_SIZE)]
         + [f"p1-{i}" for i in range(PAGE_SIZE)]
         + [f"p2-{i}" for i in range(4)]
     )
     assert len(out) == 24
-    assert state["calls"] == 3  # exactly 3 fetches, no trailing probe
-    # The handshake: first request seeds "", then each backend cursor is echoed.
-    assert state["sent_cursors"] == ["", "cur-1", "cur-2"]
-
-
-def test_e2e_contract_missing_cursor_terminates(monkeypatch):
-    """A non-keyset / older backend that returns no `cursor` (and no `last`)
-    must terminate after the first page rather than loop forever."""
-    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    # Full page, last absent, cursor absent → terminate (no next token).
-    p0 = {
-        "data": {
-            "content": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)],
-            "size": PAGE_SIZE,
-            # no `last`, no `cursor`
-        }
-    }
-    stream, state = _e2e_stream([p0])
-    out = list(stream.request_records(context=None))
-    assert len(out) == PAGE_SIZE
-    assert state["calls"] == 1  # terminates immediately, no runaway
-    assert state["sent_cursors"] == [""]
+    assert obj.sent_cursors == ["", "cur-1", "cur-2"]
+    # Intermediate STATE snapshots carried the resume cursor; final cleared it.
+    assert obj.states[0]["cursor"] == "cur-1"
+    assert "cursor" not in obj.states[-1]
 
 
 def test_e2e_contract_full_final_page_with_last_true(monkeypatch):
-    """Edge: the final page is FULL (len == page_size) but carries `last: True`.
-    Termination must come from `last`, not the short-page check."""
+    """Edge: a FULL final page (len == page_size) terminates via `last`, not the
+    short-page check."""
     monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
-    p0 = _page_json([_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], cursor="cur-1", last=False)
-    p1 = _page_json([_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], cursor="cur-2", last=True)
-    assert p1["data"]["last"] is True and len(p1["data"]["content"]) == PAGE_SIZE
-
-    stream, state = _e2e_stream([p0, p1])
-    out = list(stream.request_records(context=None))
+    pages = [
+        {"records": [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)], "cursor": "cur-1", "last": False},
+        {"records": [_rec("other", f"p1-{i}") for i in range(PAGE_SIZE)], "cursor": "cur-2", "last": True},
+    ]
+    obj = _run_stream(pages, stream_state={}, start_date=parse("2026-01-01T00:00:00Z"))
+    out = list(obj.request_records(context=None))
     assert len(out) == 2 * PAGE_SIZE
-    assert state["calls"] == 2  # full final page still stops via `last`
-    assert state["sent_cursors"] == ["", "cur-1"]
+    assert obj.sent_cursors == ["", "cur-1"]
 
 
-# ---- bookmark signpost ----
+# =====================================================================================
+# AccountStream: narrow the exception catch (Mycroft #2)
+# =====================================================================================
 
-def test_replication_key_signpost_returns_now_not_none():
-    """When 0 records are yielded (e.g., all-HotGlue tenant), state must still
-    advance. Singer SDK caps state at the signpost; returning a fresh "now"
-    moves the bookmark forward even when nothing yielded."""
-    from datetime import datetime, timezone
+def _account_super_raises(monkeypatch, exc):
+    """Patch the parent CBX1Stream.request_records to raise `exc`, so AccountStream's
+    `yield from super().request_records(...)` triggers its except handler."""
+    import tap_cbx1.client as client_mod
 
-    from tap_cbx1.client import CBX1Stream
+    def raising(self, context):
+        raise exc
+        yield  # pragma: no cover - makes this a generator
 
-    obj = SimpleNamespace()
-    signpost = CBX1Stream.get_replication_key_signpost(obj, context=None)
-    assert signpost is not None
-    # pendulum DateTime is a subclass of datetime; should be tz-aware and "now-ish".
-    delta = abs((datetime.now(timezone.utc) - signpost).total_seconds())
-    assert delta < 5
+    monkeypatch.setattr(client_mod.CBX1Stream, "request_records", raising)
+
+
+def test_account_stream_swallows_fatal_api_error(monkeypatch):
+    """A missing ACCOUNT mapping surfaces as a 4xx -> FatalAPIError -> swallowed
+    (yield nothing) rather than failing the run."""
+    from singer_sdk.exceptions import FatalAPIError
+    from tap_cbx1.streams import AccountStream
+
+    _account_super_raises(monkeypatch, FatalAPIError("400 Client Error: mapping not found"))
+    inst = object.__new__(AccountStream)
+    out = list(AccountStream.request_records(inst, context=None))
+    assert out == []
+
+
+def test_account_stream_propagates_retriable_error(monkeypatch):
+    """A transient failure (5xx/timeout -> RetriableAPIError) must NOT be swallowed —
+    swallowing it would record false success and drop records."""
+    from singer_sdk.exceptions import RetriableAPIError
+    from tap_cbx1.streams import AccountStream
+
+    _account_super_raises(monkeypatch, RetriableAPIError("503 Service Unavailable"))
+    inst = object.__new__(AccountStream)
+    with pytest.raises(RetriableAPIError):
+        list(AccountStream.request_records(inst, context=None))
+
+
+def test_account_stream_propagates_keyset_anomaly(monkeypatch):
+    """The incompatible-backend RuntimeError guard must also propagate through the
+    account stream (no silent swallow)."""
+    from tap_cbx1.streams import AccountStream
+
+    _account_super_raises(monkeypatch, RuntimeError("full page, no cursor, not last"))
+    inst = object.__new__(AccountStream)
+    with pytest.raises(RuntimeError):
+        list(AccountStream.request_records(inst, context=None))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -510,9 +510,22 @@ def test_e2e_contract_full_final_page_with_last_true(monkeypatch):
 # AccountStream: narrow the exception catch (Mycroft #2)
 # =====================================================================================
 
+def _account_instance(state=None):
+    """A real AccountStream instance whose stream_state is backed by tap_state.
+
+    (stream_state is a read-only property, so it cannot be set as an attribute.)
+    """
+    from tap_cbx1.streams import AccountStream
+
+    inst = object.__new__(AccountStream)
+    inst.name = "accounts"
+    inst._tap_state = {"bookmarks": {"accounts": dict(state or {})}}
+    return inst
+
+
 def _account_super_raises(monkeypatch, exc):
-    """Patch the parent CBX1Stream.request_records to raise `exc`, so AccountStream's
-    `yield from super().request_records(...)` triggers its except handler."""
+    """Patch the parent CBX1Stream.request_records to raise `exc` immediately (before
+    any progress), so AccountStream's `yield from super()...` triggers its handler."""
     import tap_cbx1.client as client_mod
 
     def raising(self, context):
@@ -522,36 +535,107 @@ def _account_super_raises(monkeypatch, exc):
     monkeypatch.setattr(client_mod.CBX1Stream, "request_records", raising)
 
 
-def test_account_stream_swallows_fatal_api_error(monkeypatch):
-    """A missing ACCOUNT mapping surfaces as a 4xx -> FatalAPIError -> swallowed
-    (yield nothing) rather than failing the run."""
+def test_account_stream_swallows_fatal_on_fresh_first_page(monkeypatch):
+    """A missing ACCOUNT mapping fails the FIRST fetch with a 4xx (FatalAPIError)
+    before any progress -> swallowed (yield nothing) rather than failing the run."""
     from singer_sdk.exceptions import FatalAPIError
     from tap_cbx1.streams import AccountStream
 
     _account_super_raises(monkeypatch, FatalAPIError("400 Client Error: mapping not found"))
-    inst = object.__new__(AccountStream)
-    out = list(AccountStream.request_records(inst, context=None))
+    out = list(AccountStream.request_records(_account_instance({}), context=None))
     assert out == []
 
 
 def test_account_stream_propagates_retriable_error(monkeypatch):
-    """A transient failure (5xx/timeout -> RetriableAPIError) must NOT be swallowed —
-    swallowing it would record false success and drop records."""
+    """A transient failure (5xx/timeout -> RetriableAPIError) must NOT be swallowed."""
     from singer_sdk.exceptions import RetriableAPIError
     from tap_cbx1.streams import AccountStream
 
     _account_super_raises(monkeypatch, RetriableAPIError("503 Service Unavailable"))
-    inst = object.__new__(AccountStream)
     with pytest.raises(RetriableAPIError):
-        list(AccountStream.request_records(inst, context=None))
+        list(AccountStream.request_records(_account_instance({}), context=None))
 
 
 def test_account_stream_propagates_keyset_anomaly(monkeypatch):
-    """The incompatible-backend RuntimeError guard must also propagate through the
-    account stream (no silent swallow)."""
+    """The incompatible-backend RuntimeError guard must also propagate (no swallow)."""
     from tap_cbx1.streams import AccountStream
 
     _account_super_raises(monkeypatch, RuntimeError("full page, no cursor, not last"))
-    inst = object.__new__(AccountStream)
     with pytest.raises(RuntimeError):
+        list(AccountStream.request_records(_account_instance({}), context=None))
+
+
+def _account_run_instance(transport, *, state=None, start_date=None):
+    """A real AccountStream instance wired to drive the REAL parent request_records
+    over `transport`, so cursor persistence actually happens. stream_state is backed
+    by tap_state and page_size by config (both are read-only properties)."""
+    from tap_cbx1.streams import AccountStream
+
+    inst = object.__new__(AccountStream)
+    inst.name = "accounts"
+    inst._tap_state = {"bookmarks": {"accounts": dict(state or {})}}
+    inst._config = {"page_size": PAGE_SIZE}
+    inst.get_starting_time = lambda ctx: start_date
+    inst.prepare_request = lambda context, next_page_token: f"req-{next_page_token}"
+    inst.request_decorator = lambda fn: fn
+    inst._request = transport
+    inst._write_state_message = lambda: None
+    return inst
+
+
+def test_account_stream_propagates_fatal_after_progress_no_wedge(monkeypatch):
+    """Regression (the persisted-cursor wedge): page 1 succeeds (cursor persisted),
+    then page 2 raises FatalAPIError. The error MUST propagate, not be swallowed —
+    otherwise the persisted cursor would make every later run resume to the same
+    failing page, swallow again, and never advance or clear (permanent wedge)."""
+    from singer_sdk.exceptions import FatalAPIError
+    from tap_cbx1.streams import AccountStream
+
+    monkeypatch.delenv("HOTGLUE_PRINCIPAL_ID", raising=False)
+    calls = {"n": 0}
+    p0 = [_rec("other", f"p0-{i}") for i in range(PAGE_SIZE)]
+
+    def transport(*_a, **_k):
+        i = calls["n"]
+        calls["n"] += 1
+        if i == 0:
+            resp = MagicMock()
+            resp.json.return_value = {"data": {"content": p0, "cursor": "c1", "last": False, "size": PAGE_SIZE}}
+            return resp
+        raise FatalAPIError("413 Client Error mid-window")
+
+    inst = _account_run_instance(transport, state={})
+    out = []
+    with pytest.raises(FatalAPIError):
+        for r in AccountStream.request_records(inst, context=None):
+            out.append(r)
+
+    assert [r["id"] for r in out] == [f"p0-{i}" for i in range(PAGE_SIZE)]
+    # Progress was persisted and the mid-window 4xx propagated (loud), not swallowed.
+    assert inst.stream_state["cursor"] == "c1"
+
+
+def test_account_stream_swallows_fatal_only_before_progress_with_all_filtered_page(monkeypatch):
+    """Edge of the guard: page 1 is a FULL page of all-HotGlue records (yields
+    nothing) so a cursor IS persisted, then page 2 raises FatalAPIError. Even though
+    nothing was yielded, the persisted cursor means progress was made -> propagate."""
+    from singer_sdk.exceptions import FatalAPIError
+    from tap_cbx1.streams import AccountStream
+
+    monkeypatch.setenv("HOTGLUE_PRINCIPAL_ID", HOTGLUE_UUID)
+    calls = {"n": 0}
+    all_hotglue = _full_page(HOTGLUE_UUID, "p0")
+
+    def transport(*_a, **_k):
+        i = calls["n"]
+        calls["n"] += 1
+        if i == 0:
+            resp = MagicMock()
+            resp.json.return_value = {"data": {"content": all_hotglue, "cursor": "c1", "last": False, "size": PAGE_SIZE}}
+            return resp
+        raise FatalAPIError("400 Client Error mid-window")
+
+    inst = _account_run_instance(transport, state={})
+    with pytest.raises(FatalAPIError):
         list(AccountStream.request_records(inst, context=None))
+    assert inst.stream_state["cursor"] == "c1"


### PR DESCRIPTION
## What this PR does

Two things, both on the egestion read path:

**1. Keyset/cursor pagination** (replaces page-number/skip). Deep skip (`skip = pageNumber * pageSize`) made the backend walk the whole prefix before each deep page → prod Mongo `CM100` timeout / CPU spike on large orgs. The tap now sends the backend's opaque `(updatedAt, id)` cursor (`""` on the first page, then echoes `data.cursor`). Matching backend: **CBX1/backend#4822**.

**2. Durable forward progress.** The cursor alone is only intra-run; a run that ended partway (wall-clock on a big backfill, transient error, OOM) discarded all progress and restarted the window from the top. Now:
- The next-page cursor + a **pinned window upper bound** are persisted to Singer state **after each page's records are emitted** (crash-safe: no dup, no skip).
- The next run **resumes from that cursor against the same pinned window** and reads only the unread remainder. The window end is pinned (not a fresh `now()`) because the DESC sort would otherwise let records that arrived between runs slip in at the top and be skipped.
- The run-to-run `updatedAt` bookmark advances to the pinned window end (and the cursor clears) **only on confirmed completion** (`data.last` / short page). The SDK's record-driven high-watermark is disabled — it assumes ASC and finalizes on *any* clean return, which under DESC would commit the newest `updatedAt` (page 1) on a partial run and silently skip the older tail.
- `page_size` is now configurable (default **500**); keyset has no per-page skip cost, so larger pages just cut round-trips (200k records: ~400 requests @500 vs ~20k @10).

```mermaid
flowchart LR
  A["per-run window + pageNumber skip<br/>(partial run discards all progress)"] --> B["keyset cursor + pinned window in STATE<br/>(resume reads only the unread remainder)"]
```

## Notes

- **Deploy backend-first with jobs stopped** (per the owner). The tap fails loudly if it sees an incompatible backend (see review response below), so it cannot silently advance against an old backend.
- Tests: **33 passing** — mid-run failure persists a resume cursor without advancing the watermark; resume reads only the remainder against the pinned window; completion advances + clears; the incompatible-backend anomaly raises without advancing; `AccountStream` swallows `FatalAPIError` but propagates `RetriableAPIError`/`RuntimeError`.
- Tracking: beads `watson-9we`.

## Review responses (Mycroft)

- **Deploy risk / silent data loss (`client.py`)** — agree on the *risk*, different fix. A full page that is **not** `last` and carries **no** cursor now raises (`RuntimeError`) instead of terminating, so an old/non-keyset backend can no longer make the bookmark jump to ~now and drop the unread tail. I did **not** add the suggested `pageNumber` + `totalPages` fallback: that would re-introduce the exact deep-skip this PR removes and mask the incompatibility. Rollout is backend-first with jobs stopped.
- **Broad `except Exception` (`streams.py`)** — good catch, fixed. Narrowed to `FatalAPIError` (the SDK's 4xx wrapper = missing ACCOUNT mapping). Transient `RetriableAPIError` (5xx/timeouts) and the keyset-anomaly `RuntimeError` now propagate.
- **Defensive `data` parse (`client.py`)** — applied: `(resp.json().get('data') or {}).get('content') or []`.
